### PR TITLE
fix(types): declare ambient SCSS/CSS modules for TypeScript 6

### DIFF
--- a/src/scss.d.ts
+++ b/src/scss.d.ts
@@ -1,0 +1,10 @@
+// Ambient declarations for side-effect stylesheet imports.
+//
+// These imports (see src/index.tsx) exist purely to pull stylesheets into the
+// bundle; the esbuild SCSS plugin handles them at build time. TypeScript itself
+// never resolves them, and TypeScript 6 promotes an untyped side-effect import
+// to a hard error (TS2882: "Cannot find module or type declarations for
+// side-effect import of ..."). Declaring the wildcard modules keeps tsc quiet
+// without affecting the build.
+declare module '*.scss';
+declare module '*.css';


### PR DESCRIPTION
## Problem

TypeScript 6 promotes untyped side-effect imports to a hard error. `tsc --noEmit` fails on the two stylesheet imports in `src/index.tsx`:

```
src/index.tsx(28,8): error TS2882: Cannot find module or type declarations for side-effect import of 'patternfly/patternfly-6-cockpit.scss'.
src/index.tsx(29,8): error TS2882: Cannot find module or type declarations for side-effect import of './app.scss'.
```

These imports exist purely to pull stylesheets into the bundle; the esbuild SCSS plugin handles them at build time and `tsc` never resolves them.

## Fix

Add `src/scss.d.ts` with wildcard ambient module declarations for `*.scss` and `*.css`.

## Verification

Ran `tsc --noEmit` locally against both compiler versions:

| | without fix | with fix |
|---|---|---|
| TypeScript 5.9.3 (current) | pass | pass |
| TypeScript 6.0.3 | **TS2882 (fails)** | pass |

`format:check`, `eslint`, and `stylelint` all pass.

This unblocks the TypeScript 5.9 -> 6.0 dependabot upgrade in #62 (which fails on exactly these two errors). Once this lands, #62 can be rebased and merged.