### PR TITLE
chore(ci): stop unmergeable bot PRs from piling up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,13 @@ updates:
       - dependency-name: "*react*"
         update-types: ["version-update:semver-major"]
 
+      # eslint-plugin-react (7.37.5, latest) supports eslint only up to ^9.7. ESLint 10
+      # removed the legacy context.getFilename() API the plugin relies on, so bumping
+      # eslint to 10 breaks linting (TypeError loading react rules). Hold eslint on 9.x
+      # until eslint-plugin-react ships ESLint 10 support.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,17 +27,8 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
 
-  auto-merge-bots:
-    name: Auto-merge bot PRs
-    runs-on: ubuntu-latest
-    if: >-
-      github.actor == 'github-actions[bot]' && (
-        startsWith(github.event.pull_request.title, 'cockpit-lib-update') ||
-        startsWith(github.event.pull_request.title, 'tasks-container-update')
-      )
-    steps:
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+  # Note: there is intentionally no job for github-actions[bot] PRs here. Those PRs
+  # (cockpit-lib-update, tasks-container-update) are created with the default
+  # GITHUB_TOKEN, which by design does not trigger pull_request_target, so such a
+  # job would never run. Those workflows are now manual-dispatch only and merged by
+  # hand instead.

--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -1,8 +1,13 @@
 name: cockpit-lib-update
+# The scheduled trigger is intentionally disabled. This job opens its PR with the
+# default GITHUB_TOKEN, and GitHub does not let GITHUB_TOKEN-created PRs trigger
+# other workflows. CI therefore never runs on these PRs, so they can never satisfy
+# branch protection (required status checks plus a review) and merge on their own.
+# Left on a schedule they just pile up, one unmergeable PR every week. Run this on
+# demand instead (for example before a release), then review and merge the PR.
 on:
-  schedule:
-    - cron: '0 2 * * 4'
-  # can be run manually on https://github.com/cockpit-project/starter-kit/actions
+  # schedule:
+  #   - cron: '0 2 * * 4'
   workflow_dispatch:
 jobs:
   cockpit-lib-update:

--- a/.github/workflows/tasks-container-update.yml
+++ b/.github/workflows/tasks-container-update.yml
@@ -1,8 +1,10 @@
 name: tasks-container-update
+# Scheduled trigger disabled for the same reason as cockpit-lib-update: PRs opened
+# with the default GITHUB_TOKEN do not trigger CI, so they cannot satisfy branch
+# protection and would accumulate as unmergeable PRs. Run on demand when needed.
 on:
-  schedule:
-    - cron: '0 2 * * 1'
-  # can be run manually on https://github.com/cockpit-project/starter-kit/actions
+  # schedule:
+  #   - cron: '0 2 * * 1'
   workflow_dispatch:
 jobs:
   tasks-container-update:


### PR DESCRIPTION
## Why

The open-PR queue had filled with automated bot PRs that can never merge themselves:
- 11 `cockpit-lib-update` PRs open at once (plus 38 dangling branches).
- A recurring `eslint` 9 to 10 bump that fails CI and gets auto-closed every few weeks.

### Root cause

`cockpit-lib-update` and `tasks-container-update` open their PRs with the default `GITHUB_TOKEN`. GitHub deliberately does not let `GITHUB_TOKEN`-created PRs trigger other workflows, so **CI never runs on them** (0 CI runs on cockpit-lib branches, vs 62 on dependabot branches) and they can never satisfy branch protection (required checks + review). Dependabot is exempt from that restriction, which is why its patch/minor PRs already auto-merge fine.

The `auto-merge-bots` job was meant to handle these but listens on `pull_request_target`, which those PRs never trigger, so it has never run once.

## Changes

- **Disable the weekly schedule** on `cockpit-lib-update` and `tasks-container-update`; keep `workflow_dispatch` so the vendored Cockpit lib / tasks container can still be updated on demand (run it, review, merge).
- **Remove the dead `auto-merge-bots` job** from `auto-merge.yml` (kept the working dependabot job).
- **Ignore `eslint` semver-major in dependabot.** `eslint-plugin-react` 7.37.5 (latest on npm) supports eslint only up to `^9.7`; ESLint 10 removed the `context.getFilename()` API the plugin uses, so the bump breaks linting. This stops the recurring failing eslint PR until the plugin ships ESLint 10 support.

## Out of scope / done separately

- Merged the latest cockpit-lib update (#79) and closed the 10 superseded ones.
- Deleted 38 dead cockpit-lib branches.
- Merged the 4 green major dependabot PRs (#65, #60, #59, #55).
- TypeScript 6 fix is in #80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to disable automatic scheduled runs for dependency and container update workflows (now manual-dispatch only).
  * Modified Dependabot configuration to prevent incompatible major version updates for eslint due to known plugin compatibility issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/cockpit-birdnet-go/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->