### PR TITLE
chore(deps): upgrade React 18 -> 19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,10 @@ updates:
       - dependency-name: "@patternfly/*"
         update-types: ["version-update:semver-major"]
 
-      # PF5 requires React 18
+      # React major bumps are reviewed manually. PatternFly 6 supports React
+      # 17/18/19, so this is not a hard compatibility cap; we just want major
+      # React upgrades to go through a deliberate PR rather than land
+      # automatically. Currently on React 19.
       - dependency-name: "*react*"
         update-types: ["version-update:semver-major"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
         "@patternfly/react-core": "6.5.1",
         "@patternfly/react-icons": "6.5.1",
         "@patternfly/react-styles": "6.5.1",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react": "19.2.6",
+        "react-dom": "19.2.6"
       },
       "devDependencies": {
-        "@types/react": "18.3.13",
-        "@types/react-dom": "18.3.1",
+        "@types/react": "19.2.15",
+        "@types/react-dom": "19.2.3",
         "@vitest/coverage-v8": "^4.1.0",
         "argparse": "2.0.1",
         "esbuild": "0.28.0",
@@ -2055,32 +2055,24 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.13.tgz",
-      "integrity": "sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6875,28 +6867,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-dropzone": {
@@ -7579,13 +7567,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@types/react": "18.3.13",
-    "@types/react-dom": "18.3.1",
+    "@types/react": "19.2.15",
+    "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "^4.1.0",
     "argparse": "2.0.1",
     "esbuild": "0.28.0",
@@ -55,7 +55,7 @@
     "@patternfly/react-core": "6.5.1",
     "@patternfly/react-icons": "6.5.1",
     "@patternfly/react-styles": "6.5.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   }
 }


### PR DESCRIPTION
## Summary

Upgrades React from 18 to 19. The previous `dependabot.yml` hold claimed PatternFly required React 18, but that reasoning is stale: the project is on PatternFly 6, whose `react-core` declares a peer range of `react: "^17 || ^18 || ^19"`.

- `react` / `react-dom` 18.3.1 -> 19.2.6
- `@types/react` 18.3.13 -> 19.2.15
- `@types/react-dom` 18.3.1 -> 19.2.3
- `dependabot.yml`: corrected the stale "PF5 requires React 18" comment; React majors remain gated for manual review

No source changes were required. React is bundled by esbuild (not externalized), so the host Cockpit React version is unaffected, and the code already uses only modern APIs (`createRoot` from `react-dom/client`; no `ReactDOM.render` / `findDOMNode` / `defaultProps` / string refs). The single `useRef` call already passes an initial argument (satisfies React 19's tightened types) and the only class component is `ErrorBoundary` (fully supported in 19).

## Test Plan

- [x] `npm run build`
- [x] `npm run eslint`
- [x] `npm run stylelint`
- [x] `npm run typecheck` (clean against `@types/react` 19)
- [x] `npm test` (112/112 pass)
- [x] `npm audit` reports 0 vulnerabilities
- [ ] Runtime smoke test in a live Cockpit dashboard (existing tests are logic-only and do not render components)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Upgraded React and React DOM runtime dependencies from version 18.3.1 to version 19.2.6, along with corresponding TypeScript type definitions to maintain compatibility
* Updated dependency management policy documentation to clarify the review process for React major version upgrades and current targeting of React 19

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/cockpit-birdnet-go/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->