### PR TITLE
chore(packaging): fix starter-kit leftovers and OBS workflow

### DIFF
--- a/.github/workflows/obs-submit.yml
+++ b/.github/workflows/obs-submit.yml
@@ -1,261 +1,126 @@
 name: Submit to Open Build Service
 
+# Pushes a release to the openSUSE Build Service (OBS), which builds the RPM
+# for the configured openSUSE/Fedora targets.
+#
+# This reuses the canonical packaging (packaging/cockpit-birdnet-go.spec.in plus
+# the make targets) instead of hand-rolling a spec, so the OBS build stays in
+# sync with the local `make rpm` / Packit builds and the LGPL-2.1-or-later
+# license. The Debian package is produced separately by release.yml and attached
+# to the GitHub release; building .deb on OBS would need a proper Debian source
+# package and is left as a follow-up.
+#
+# Required repository configuration before enabling:
+#   - variable OBS_ENABLED = "true"
+#   - secret   OBS_USERNAME
+#   - secret   OBS_PASSWORD
+#   - secret   OBS_PROJECT   (optional; defaults to home:<OBS_USERNAME>)
+
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., 1.0.1)'
+        description: 'Tag to build (e.g. v1.0.2); defaults to the checked-out ref'
         required: false
         type: string
 
 jobs:
   submit-to-obs:
     runs-on: ubuntu-latest
-    # Only run if OBS secrets are configured
+    # Only run when OBS credentials have been configured
     if: ${{ vars.OBS_ENABLED == 'true' }}
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
-      
-    - name: Determine version
-      run: |
-        if [ "${{ github.event_name }}" = "release" ]; then
-          VERSION=${GITHUB_REF_NAME#v}  # Remove 'v' prefix from tag
-        elif [ -n "${{ inputs.version }}" ]; then
-          VERSION="${{ inputs.version }}"
-        else
-          VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')"
-        fi
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "Building version: $VERSION"
-        
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20'
-        
-    - name: Install dependencies and build
-      run: |
-        npm ci --legacy-peer-deps
-        npm run build
-        
-    - name: Create distribution package
-      run: |
-        # Create distribution directory with built files
-        mkdir -p cockpit-birdnet-go-${{ env.VERSION }}
-        cp -r dist/* cockpit-birdnet-go-${{ env.VERSION }}/
-        cp manifest.json cockpit-birdnet-go-${{ env.VERSION }}/
-        
-        # Create source tarball
-        tar czf cockpit-birdnet-go-${{ env.VERSION }}.tar.gz cockpit-birdnet-go-${{ env.VERSION }}/
-        
-        # Create orig tarball for Debian
-        cp cockpit-birdnet-go-${{ env.VERSION }}.tar.gz cockpit-birdnet-go_${{ env.VERSION }}.orig.tar.gz
-        
-    - name: Install osc (OBS CLI)
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y osc
-        
-    - name: Configure osc securely
-      run: |
-        # Create osc config directory
-        mkdir -p ~/.config/osc
-        
-        # Write configuration (credentials from secrets)
-        cat > ~/.config/osc/oscrc << 'EOF'
-        [general]
-        apiurl = https://api.opensuse.org
-        
-        [https://api.opensuse.org]
-        user = ${{ secrets.OBS_USERNAME }}
-        pass = ${{ secrets.OBS_PASSWORD }}
-        credentials_mgr_class = osc.credentials.PlaintextConfigFileCredentialsManager
-        EOF
-        
-        # Secure the config file
-        chmod 600 ~/.config/osc/oscrc
-        
-    - name: Create RPM spec file
-      run: |
-        cat > cockpit-birdnet-go.spec << 'EOF'
-        Name:           cockpit-birdnet-go
-        Version:        ${{ env.VERSION }}
-        Release:        1%{?dist}
-        Summary:        Cockpit plugin for BirdNET-Go service management
-        License:        MIT
-        URL:            https://github.com/tphakala/cockpit-birdnet-go
-        Source0:        %{name}-%{version}.tar.gz
-        
-        BuildArch:      noarch
-        Requires:       cockpit >= 215
-        
-        %description
-        A Cockpit plugin that provides a web interface for managing
-        BirdNET-Go bird sound identification service. It allows users to
-        control the service, view logs, and manage updates through
-        Cockpit's web interface.
-        
-        %prep
-        %setup -q
-        
-        %build
-        # Already built in tarball
-        
-        %install
-        mkdir -p %{buildroot}%{_datadir}/cockpit/birdnet-go
-        cp -a * %{buildroot}%{_datadir}/cockpit/birdnet-go/
-        
-        %files
-        %{_datadir}/cockpit/birdnet-go
-        
-        %changelog
-        * $(date '+%a %b %d %Y') GitHub Actions <noreply@github.com> - %{version}-1
-        - Automated build from GitHub release %{version}
-        EOF
-        
-    - name: Create Debian packaging files
-      run: |
-        mkdir -p debian/source
-        
-        # debian/control
-        cat > debian/control << 'EOF'
-        Source: cockpit-birdnet-go
-        Section: admin
-        Priority: optional
-        Maintainer: GitHub Actions <noreply@github.com>
-        Build-Depends: debhelper-compat (= 13)
-        Standards-Version: 4.6.2
-        Homepage: https://github.com/tphakala/cockpit-birdnet-go
-        Rules-Requires-Root: no
-        
-        Package: cockpit-birdnet-go
-        Architecture: all
-        Depends: ${misc:Depends}, cockpit (>= 215)
-        Description: Cockpit plugin for BirdNET-Go service management
-         A Cockpit plugin that provides a web interface for managing
-         BirdNET-Go bird sound identification service. It allows users to
-         control the service, view logs, and manage updates through
-         Cockpit's web interface.
-        EOF
-        
-        # debian/changelog
-        cat > debian/changelog << EOF
-        cockpit-birdnet-go (${{ env.VERSION }}-1) unstable; urgency=medium
-        
-          * Release version ${{ env.VERSION }}
-          * See https://github.com/tphakala/cockpit-birdnet-go/releases/tag/v${{ env.VERSION }}
-        
-         -- GitHub Actions <noreply@github.com>  $(date -R)
-        EOF
-        
-        # debian/rules
-        cat > debian/rules << 'EOF'
-        #!/usr/bin/make -f
-        
-        %:
-        	dh $@
-        
-        override_dh_auto_build:
-        	# Already built
-        
-        override_dh_auto_install:
-        	mkdir -p debian/cockpit-birdnet-go/usr/share/cockpit/birdnet-go
-        	cp -a dist/* debian/cockpit-birdnet-go/usr/share/cockpit/birdnet-go/
-        	cp manifest.json debian/cockpit-birdnet-go/usr/share/cockpit/birdnet-go/
-        
-        override_dh_auto_test:
-        	# No tests needed for pre-built package
-        EOF
-        chmod +x debian/rules
-        
-        # debian/compat
-        echo "13" > debian/compat
-        
-        # debian/source/format
-        echo "3.0 (quilt)" > debian/source/format
-        
-        # Create debian source package
-        tar czf debian.tar.gz debian/
-        
-    - name: Create OBS _service file
-      run: |
-        # This service file allows OBS to fetch sources
-        cat > _service << 'EOF'
-        <services>
-          <service name="download_url">
-            <param name="protocol">https</param>
-            <param name="host">github.com</param>
-            <param name="path">/tphakala/cockpit-birdnet-go/releases/download/v${{ env.VERSION }}/cockpit-birdnet-go-${{ env.VERSION }}.tar.gz</param>
-            <param name="filename">cockpit-birdnet-go-${{ env.VERSION }}.tar.gz</param>
-          </service>
-          
-          <service name="set_version">
-            <param name="version">${{ env.VERSION }}</param>
-          </service>
-        </services>
-        EOF
-        
-    - name: Prepare OBS submission
-      run: |
-        # Set OBS project path from secret or default
-        OBS_PROJECT="${{ secrets.OBS_PROJECT || format('home:{0}', secrets.OBS_USERNAME) }}"
-        echo "OBS_PROJECT=$OBS_PROJECT" >> $GITHUB_ENV
-        
-        # Check if package exists, create if needed
-        if ! osc meta pkg "$OBS_PROJECT" cockpit-birdnet-go &>/dev/null; then
-          echo "Creating new package in OBS..."
-          cat > meta.xml << EOF
-        <package name="cockpit-birdnet-go" project="$OBS_PROJECT">
-          <title>Cockpit BirdNET-Go Plugin</title>
-          <description>A Cockpit plugin for managing BirdNET-Go service</description>
-          <url>https://github.com/tphakala/cockpit-birdnet-go</url>
-        </package>
-        EOF
-          osc meta pkg -F meta.xml "$OBS_PROJECT" cockpit-birdnet-go
-        fi
-        
-    - name: Checkout OBS package
-      run: |
-        osc checkout "${{ env.OBS_PROJECT }}" cockpit-birdnet-go
-        cd "${{ env.OBS_PROJECT }}/cockpit-birdnet-go"
-        
-    - name: Update OBS package
-      run: |
-        cd "${{ env.OBS_PROJECT }}/cockpit-birdnet-go"
-        
-        # Remove old files
-        rm -f *.spec *.tar.gz *.dsc *.debian.tar.* _service
-        
-        # Copy new files
-        cp ../../cockpit-birdnet-go.spec .
-        cp ../../cockpit-birdnet-go-${{ env.VERSION }}.tar.gz .
-        cp ../../cockpit-birdnet-go_${{ env.VERSION }}.orig.tar.gz .
-        cp ../../debian.tar.gz .
-        cp ../../_service .
-        
-        # Add files to OBS
-        osc addremove
-        
-        # Show what will be committed
-        osc diff
-        
-        # Commit to OBS
-        osc commit -m "Update to version ${{ env.VERSION }} from GitHub release"
-        
-    - name: Trigger OBS builds
-      run: |
-        echo "Triggering builds for all configured repositories..."
-        osc rebuildpac "${{ env.OBS_PROJECT }}" cockpit-birdnet-go
-        
-    - name: Check build status
-      run: |
-        echo "Checking initial build status..."
-        sleep 10  # Give OBS a moment to start builds
-        osc results "${{ env.OBS_PROJECT }}" cockpit-birdnet-go
-        echo ""
-        echo "Builds have been triggered. Check OBS web interface for detailed status:"
-        echo "https://build.opensuse.org/package/show/${{ env.OBS_PROJECT }}/cockpit-birdnet-go"
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # need full history + tags so `git describe` (make's version source) works
+          fetch-depth: 0
+
+      - name: Check out requested tag (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+        run: git checkout "refs/tags/${{ inputs.version }}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install build and OBS tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make gettext osc
+
+      - name: Build release tarballs and spec
+        id: build
+        run: |
+          set -eux
+          # canonical artifacts: source tarball, bundled node_modules cache, and
+          # the spec generated from packaging/cockpit-birdnet-go.spec.in
+          make dist
+          make node-cache
+          make cockpit-birdnet-go.spec
+
+          tarball=$(ls cockpit-birdnet-go-*.tar.xz | grep -v -- '-node-')
+          node_tarball=$(ls cockpit-birdnet-go-node-*.tar.xz)
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          echo "node_tarball=$node_tarball" >> "$GITHUB_OUTPUT"
+          echo "Built $tarball and $node_tarball"
+
+      - name: Configure osc
+        run: |
+          mkdir -p ~/.config/osc
+          cat > ~/.config/osc/oscrc << 'EOF'
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = ${{ secrets.OBS_USERNAME }}
+          pass = ${{ secrets.OBS_PASSWORD }}
+          credentials_mgr_class = osc.credentials.PlaintextConfigFileCredentialsManager
+          EOF
+          chmod 600 ~/.config/osc/oscrc
+
+      - name: Submit to OBS
+        env:
+          OBS_PROJECT: ${{ secrets.OBS_PROJECT || format('home:{0}', secrets.OBS_USERNAME) }}
+        run: |
+          set -eux
+
+          # create the package in the project on first run
+          if ! osc meta pkg "$OBS_PROJECT" cockpit-birdnet-go &>/dev/null; then
+            cat > meta.xml << EOF
+          <package name="cockpit-birdnet-go" project="$OBS_PROJECT">
+            <title>Cockpit BirdNET-Go Plugin</title>
+            <description>A Cockpit management interface for BirdNET-Go</description>
+            <url>https://github.com/tphakala/cockpit-birdnet-go</url>
+          </package>
+          EOF
+            osc meta pkg -F meta.xml "$OBS_PROJECT" cockpit-birdnet-go
+          fi
+
+          osc checkout "$OBS_PROJECT" cockpit-birdnet-go -o obs-pkg
+          cd obs-pkg
+
+          # refresh sources: drop old artifacts, copy the canonical spec + tarballs.
+          # The spec's Source0/Source1 basenames match the tarball names produced
+          # by `make dist` / `make node-cache`, so OBS builds from these uploads.
+          rm -f -- *.spec *.tar.xz _service
+          cp "../cockpit-birdnet-go.spec" .
+          cp "../${{ steps.build.outputs.tarball }}" .
+          cp "../${{ steps.build.outputs.node_tarball }}" .
+
+          osc addremove
+          osc diff || true
+          osc commit -m "Update to ${{ github.ref_name }} from GitHub release"
+
+      - name: Show build results
+        env:
+          OBS_PROJECT: ${{ secrets.OBS_PROJECT || format('home:{0}', secrets.OBS_USERNAME) }}
+        run: |
+          # give OBS a moment to schedule builds, then report
+          for i in 1 2 3; do sleep 10; done
+          osc results "$OBS_PROJECT" cockpit-birdnet-go || true
+          echo "Details: https://build.opensuse.org/package/show/$OBS_PROJECT/cockpit-birdnet-go"

--- a/.github/workflows/obs-submit.yml
+++ b/.github/workflows/obs-submit.yml
@@ -65,9 +65,13 @@ jobs:
 
           tarball=$(ls cockpit-birdnet-go-*.tar.xz | grep -v -- '-node-')
           node_tarball=$(ls cockpit-birdnet-go-node-*.tar.xz)
+          # actual checked-out ref (tag on release/dispatch, else short SHA);
+          # github.ref_name would be the branch name on workflow_dispatch
+          ref=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
           echo "node_tarball=$node_tarball" >> "$GITHUB_OUTPUT"
-          echo "Built $tarball and $node_tarball"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Built $tarball and $node_tarball at $ref"
 
       - name: Configure osc
         run: |
@@ -114,7 +118,7 @@ jobs:
 
           osc addremove
           osc diff || true
-          osc commit -m "Update to ${{ github.ref_name }} from GitHub release"
+          osc commit -m "Update to ${{ steps.build.outputs.ref }} from GitHub release"
 
       - name: Show build results
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 /*.whl
 /bots
 /cockpit-*.tar.xz
-/cockpit-navigator.spec
+/cockpit-birdnet-go.spec
 /coverage/
 /dist/
 /package-lock.json

--- a/org.cockpit_project.birdnet_go.metainfo.xml
+++ b/org.cockpit_project.birdnet_go.metainfo.xml
@@ -15,8 +15,8 @@
   <launchable type="cockpit-manifest">birdnet-go</launchable>
   <url type="homepage">https://github.com/tphakala/cockpit-birdnet-go</url>
   <url type="bugtracker">https://github.com/tphakala/cockpit-birdnet-go/issues</url>
-  <update_contact>tphakala@gmail.com</update_contact>
+  <update_contact>tomi.hakala@pobox.fi</update_contact>
   <developer id="com.github.tphakala">
-    <name>Tommi Häkkinen</name>
+    <name>Tomi P. Hakala</name>
   </developer>
 </component>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "git@github.com:tphakala/cockpit-birdnet-go.git",
   "author": "",
-  "license": "LGPL-2.1",
+  "license": "LGPL-2.1-or-later",
   "engines": {
     "node": ">= 16"
   },

--- a/packaging/cockpit-birdnet-go.spec.in
+++ b/packaging/cockpit-birdnet-go.spec.in
@@ -36,7 +36,10 @@ container management, monitoring, and configuration capabilities
 through the Cockpit web interface.
 
 %prep
-%autosetup -n %{name} -a 1
+# tarball unpacks to %%{name}-%%{version}/ (make's --transform), which is the
+# %%autosetup default; do not override -n to %%{name} or %%prep cd's into the
+# wrong directory and the build fails.
+%autosetup -a 1
 # ignore pre-built bundle in release tarball and rebuild it
 # but keep it in RHEL/CentOS-8/9, as that has a too old nodejs
 %if ! 0%{?rhel} || 0%{?rhel} >= 10

--- a/packit.yaml
+++ b/packit.yaml
@@ -2,7 +2,7 @@
 # To use this, enable Packit-as-a-service in GitHub: https://packit.dev/docs/packit-as-a-service/
 # See https://packit.dev/docs/configuration/ for the format of this file
 
-specfile_path: cockpit-starter-kit.spec
+specfile_path: cockpit-birdnet-go.spec
 # use the nicely formatted release description from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
 
@@ -12,12 +12,11 @@ srpm_build_deps:
 
 actions:
   post-upstream-clone:
-    - make cockpit-starter-kit.spec
+    - make cockpit-birdnet-go.spec
     # replace Source1 manually, as create-archive: can't handle multiple tarballs
     - make node-cache
     - sh -c 'sed -i "/^Source1:/ s/https:.*/$(ls *-node*.tar.xz)/" cockpit-*.spec'
   create-archive: make dist
-  # starter-kit.git has no release tags; your project can drop this once you have a release
   get-current-version: make print-version
 
 jobs:


### PR DESCRIPTION
Cleans up packaging-path bugs left over from the Cockpit starter-kit scaffolding, all of which block the official distro-packaging paths.

## Fixes

| Issue | Impact | Fix |
|-------|--------|-----|
| `packit.yaml` pointed at `cockpit-starter-kit.spec` | Packit/COPR (Fedora path) would fail; `make` generates `cockpit-birdnet-go.spec` | point `specfile_path` + post-clone action at the real name |
| `.gitignore` ignored `/cockpit-navigator.spec` (another project) | generated spec left untracked-but-not-ignored | ignore `/cockpit-birdnet-go.spec` |
| `package.json` license `LGPL-2.1` (deprecated SPDX) | inconsistent with LICENSE / spec / `debian/copyright` (all `LGPL-2.1-or-later`) | align to `LGPL-2.1-or-later` |
| `obs-submit.yml` hand-rolled a spec **mislabeled `License: MIT`**, a divergent `debian/`, and copied a nonexistent root `manifest.json` (step fails) | OBS build was broken and would mislabel an LGPL package as MIT | rewrite to build canonical artifacts via `make dist` / `make node-cache` / `make cockpit-birdnet-go.spec` and submit those |

No production code changes; full vitest suite (113 tests) passes. All workflow + packit YAML validated.

## Verified locally
- `make cockpit-birdnet-go.spec` emits `License: LGPL-2.1-or-later`.
- `make dist` / `make node-cache` produce `cockpit-birdnet-go-<v>.tar.xz` and `cockpit-birdnet-go-node-<v>.tar.xz`, whose basenames match the spec `Source0`/`Source1`, so OBS builds from the uploads.

## Not testable here
The `osc` submission steps in `obs-submit.yml` cannot run without OBS credentials. They mirror the proven `make dist` flow in `release.yml`, but the workflow is gated on `OBS_ENABLED == "true"` and should get a real dry-run before relying on it.

## Roadmap to official packaging (follow-up, needs accounts/decisions)

**openSUSE / OBS (the SUSE service):**
1. Create an OBS account, set repo secrets `OBS_USERNAME` / `OBS_PASSWORD` (and `OBS_PROJECT`, defaults to `home:<user>`), set variable `OBS_ENABLED=true`.
2. Cut a release, confirm the OBS build is green in `home:<user>`.
3. For official inclusion, submit from the devel project to `openSUSE:Factory` via `osc sr`.

**Fedora / EPEL:**
1. Uncomment the release `copr_build` job in `packit.yaml`, set your COPR owner/project, for a no-review user repo.
2. For official Fedora: package Review Request (Bugzilla) + packager sponsor, then enable `propose_downstream` / `koji_build` / `bodhi_update`.

**Known blocker for official RPM repos:** tags are `v`-prefixed, so `make print-version` yields `Version: v1.0.2`. A leading `v` in RPM `Version:` trips rpmlint/Fedora review. Worth deciding whether to drop the `v` from tags or decouple tag-from-version in the Makefile (kept out of this PR since it changes release/tarball naming conventions).