### PR TITLE
fix(packaging): make `make rpm` clean up tolerantly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,11 @@ rpm: $(TARFILE) $(NODE_CACHE) $(SPEC)
 	  --define "_buildrootdir `pwd`/build" \
 	  $(SPEC)
 	find `pwd`/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
-	rm -r "`pwd`/rpmbuild"
-	rm -r "`pwd`/output" "`pwd`/build"
+	# -f: newer rpm (4.20+, e.g. Fedora 40+) ignores _buildrootdir and keeps the
+	# buildroot under _builddir, so `pwd`/build is never created; without -f the
+	# cleanup fails and `make rpm` exits non-zero after a successful build.
+	rm -rf "`pwd`/rpmbuild"
+	rm -rf "`pwd`/output" "`pwd`/build"
 
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed


### PR DESCRIPTION
Found while validating the RPM build in a Fedora container.

The `rpm` target ended with:
```
rm -r "`pwd`/output" "`pwd`/build"
```
On rpm 4.20+ (Fedora 40+), the buildroot stays under `_builddir` and the `_buildrootdir` define is effectively ignored, so `` `pwd`/build `` is never created. The `rm -r` then fails and **`make rpm` exits non-zero even though the RPM built and validated fine** (it produces `cockpit-birdnet-go-<v>.fcNN.noarch.rpm`, `%check` appstream validation passes, then dies on cleanup).

Fix: use `rm -rf` (matching the `clean` target) so cleanup tolerates the missing dir. On older rpm where `build/` does exist, behavior is unchanged.

Validated in a Fedora container: full `%prep`/`%build`/`%install`/`%check` lifecycle plus a clean exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package build cleanup so leftover build directories are removed more reliably.
  * Reduced the chance of build or packaging steps failing during cleanup on newer RPM versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->