### PR TITLE
M0: deployment-driver foundation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -133,7 +133,7 @@ export const Application = () => {
         exists: isSystemdKind,
         running: isSystemdKind && deployment.running,
         enabled: deployment.systemdEnabled ?? false,
-        ...(deployment.statusText !== undefined && { status: deployment.statusText }),
+        ...(deployment.systemdStatusText !== undefined && { status: deployment.systemdStatusText }),
     };
 
     const fetchLogs = useCallback(async () => {
@@ -548,13 +548,21 @@ export const Application = () => {
         return _('BirdNET-Go container running');
     };
 
-    const onStart = async () => { await driver.start(); await refreshStatus(); };
+    const onStart = async () => {
+        try { await driver.start(); await refreshStatus(); }
+        catch (e) { console.error('Error starting BirdNET-Go:', e); }
+    };
 
-    const onStop = async () => { await driver.stop(); await refreshStatus(); };
+    const onStop = async () => {
+        try { await driver.stop(); await refreshStatus(); }
+        catch (e) { console.error('Error stopping BirdNET-Go:', e); }
+    };
 
     const onRestart = async () => {
         setRestarting(true);
-        try { await driver.restart(); await refreshStatus(); } finally { setRestarting(false); }
+        try { await driver.restart(); await refreshStatus(); }
+        catch (e) { console.error('Error restarting BirdNET-Go:', e); }
+        finally { setRestarting(false); }
     };
 
     const createContainer = async () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -80,8 +80,14 @@ interface DockerInspectResult {
 
 export const Application = () => {
     const [deployment, setDeployment] = useState<Deployment>({
-        kind: 'none', runtime: null, running: false, imagePresent: false,
-        dockerAvailable: false, dockerRunning: false, hostPort: 8080, internalPort: 8080,
+        kind: 'none',
+        runtime: null,
+        running: false,
+        imagePresent: false,
+        dockerAvailable: false,
+        dockerRunning: false,
+        hostPort: 8080,
+        internalPort: 8080,
     });
     const [loading, setLoading] = useState(true);
     const [containerLogs, setContainerLogs] = useState<string>('');
@@ -549,20 +555,33 @@ export const Application = () => {
     };
 
     const onStart = async () => {
-        try { await driver.start(); await refreshStatus(); }
-        catch (e) { console.error('Error starting BirdNET-Go:', e); }
+        try {
+            await driver.start();
+            await refreshStatus();
+        } catch (e) {
+            console.error('Error starting BirdNET-Go:', e);
+        }
     };
 
     const onStop = async () => {
-        try { await driver.stop(); await refreshStatus(); }
-        catch (e) { console.error('Error stopping BirdNET-Go:', e); }
+        try {
+            await driver.stop();
+            await refreshStatus();
+        } catch (e) {
+            console.error('Error stopping BirdNET-Go:', e);
+        }
     };
 
     const onRestart = async () => {
         setRestarting(true);
-        try { await driver.restart(); await refreshStatus(); }
-        catch (e) { console.error('Error restarting BirdNET-Go:', e); }
-        finally { setRestarting(false); }
+        try {
+            await driver.restart();
+            await refreshStatus();
+        } catch (e) {
+            console.error('Error restarting BirdNET-Go:', e);
+        } finally {
+            setRestarting(false);
+        }
     };
 
     const createContainer = async () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,7 +38,6 @@ import {
     DEFAULT_CONFIG_DIR,
     DEFAULT_DATA_DIR,
     DEFAULT_LOG_DIR,
-    DOCKER_IMAGE,
     getHealthUrl,
     getImageRef,
     getWebInterfaceUrl,
@@ -49,6 +48,9 @@ import {
     SERVICE_NAME,
 } from './config';
 import type { ContainerStatus, DockerStatus, HealthStatus, LogEntry, SystemdStatus, VersionInfo } from './types';
+import { detectDeployment } from './deployment/detect';
+import { getDriver } from './deployment/driver';
+import type { Deployment } from './deployment/types';
 import {
     capitalize,
     filterLogs,
@@ -77,20 +79,13 @@ interface DockerInspectResult {
 }
 
 export const Application = () => {
-    const [dockerStatus, setDockerStatus] = useState<DockerStatus>({ available: false, running: false });
-    const [containerStatus, setContainerStatus] = useState<ContainerStatus>({
-        exists: false,
-        running: false,
-        imagePresent: false,
+    const [deployment, setDeployment] = useState<Deployment>({
+        kind: 'none', runtime: null, running: false, imagePresent: false,
+        dockerAvailable: false, dockerRunning: false, hostPort: 8080, internalPort: 8080,
     });
     const [loading, setLoading] = useState(true);
     const [containerLogs, setContainerLogs] = useState<string>('');
     const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null);
-    const [systemdStatus, setSystemdStatus] = useState<SystemdStatus>({
-        exists: false,
-        running: false,
-        enabled: false,
-    });
 
     // BirdNET-Go application logs state
     const [appLogs, setAppLogs] = useState<LogEntry[]>([]);
@@ -116,214 +111,29 @@ export const Application = () => {
         versionInfoRef.current = versionInfo;
     }, [versionInfo]);
 
-    const checkDockerStatus = async () => {
-        try {
-            // Check if Docker is available
-            const dockerVersion = await cockpit.spawn(['docker', '--version']);
-
-            // Check if Docker service is running
-            const dockerService = await cockpit.spawn(['systemctl', 'is-active', 'docker']);
-
-            setDockerStatus({
-                available: true,
-                running: dockerService.trim() === 'active',
-                version: dockerVersion.trim(),
-            });
-        } catch {
-            setDockerStatus({ available: false, running: false });
-        }
+    const driver = getDriver(deployment);
+    const isSystemdKind = deployment.kind.endsWith('-systemd');
+    const dockerStatus: DockerStatus = {
+        available: deployment.dockerAvailable,
+        running: deployment.dockerRunning,
+        ...(deployment.dockerVersion !== undefined && { version: deployment.dockerVersion }),
     };
-
-    const checkSystemdStatus = async () => {
-        try {
-            // Check if systemd service exists - use list-unit-files which doesn't require privileges
-            const serviceFiles = await cockpit.spawn([
-                'systemctl',
-                'list-unit-files',
-                '--no-pager',
-                '--plain',
-                SERVICE_NAME,
-            ]);
-            const serviceExists = serviceFiles.includes(SERVICE_NAME);
-
-            if (serviceExists) {
-                // Get simple status - these commands work without sudo
-                let isRunning = false;
-                let isEnabled = false;
-                let simpleStatus = 'inactive';
-
-                // Check if enabled
-                try {
-                    const enabledState = await cockpit.spawn(['systemctl', 'is-enabled', SERVICE_NAME]);
-                    isEnabled = enabledState.trim() === 'enabled';
-                } catch {
-                    // is-enabled returns non-zero if not enabled
-                }
-
-                // Check if active
-                try {
-                    const activeState = await cockpit.spawn(['systemctl', 'is-active', SERVICE_NAME]);
-                    simpleStatus = activeState.trim();
-                    isRunning = simpleStatus === 'active';
-                } catch {
-                    // is-active returns non-zero if not active
-                    simpleStatus = 'inactive';
-                }
-
-                setSystemdStatus({
-                    exists: true,
-                    running: isRunning,
-                    enabled: isEnabled,
-                    status: simpleStatus,
-                });
-            } else {
-                setSystemdStatus({
-                    exists: false,
-                    running: false,
-                    enabled: false,
-                });
-            }
-        } catch (error) {
-            console.error('Error checking systemd status:', error);
-            setSystemdStatus({ exists: false, running: false, enabled: false });
-        }
+    const containerStatus: ContainerStatus = {
+        exists: deployment.kind.startsWith('docker'),
+        running: deployment.running,
+        imagePresent: deployment.imagePresent,
+        isCompose: deployment.kind === 'docker-compose',
+        ...(deployment.containerId !== undefined && { containerId: deployment.containerId }),
+        ...(deployment.statusText !== undefined && { status: deployment.statusText }),
+        ...(deployment.composeProject !== undefined && { composeProject: deployment.composeProject }),
+        ...(deployment.composeService !== undefined && { composeService: deployment.composeService }),
+        ...(deployment.composeWorkingDir !== undefined && { composeWorkingDir: deployment.composeWorkingDir }),
     };
-
-    const checkBirdNetGoStatus = async () => {
-        try {
-            // Check if BirdNET-Go image exists
-            const images = await cockpit.spawn(['docker', 'images', '--format', '{{.Repository}}:{{.Tag}}']);
-            const imagePresent = images.includes(DOCKER_IMAGE);
-
-            // First, try to check if BirdNET-Go is running via health API
-            let isActuallyRunning = false;
-            try {
-                const result = await cockpit.spawn([
-                    'curl',
-                    '-s', // Silent mode
-                    '-m',
-                    '2', // 2 second timeout
-                    getHealthUrl(window.location.hostname),
-                ]);
-
-                if (result) {
-                    const healthData = safeJsonParse<{ status?: string }>(
-                        result,
-                        {},
-                        'health check during status detection'
-                    );
-                    isActuallyRunning = healthData.status === 'healthy' || healthData.status === 'degraded';
-                } else {
-                    isActuallyRunning = false;
-                }
-            } catch {
-                // Expected if the service is not running
-                isActuallyRunning = false;
-            }
-
-            // Check for BirdNET-Go containers - get all containers with labels
-            const containers = await cockpit.spawn([
-                'docker',
-                'ps',
-                '-a',
-                '--format',
-                '{{.ID}}|{{.Image}}|{{.Status}}|{{.Names}}|{{.Labels}}',
-            ]);
-
-            if (containers.trim()) {
-                const containerLines = containers.trim().split('\n');
-
-                // Find BirdNET-Go container by image name or container name
-                // Be specific to avoid matching VSCode dev containers
-                const birdnetContainer = containerLines.find(line => {
-                    const parts = line.split('|');
-                    const image = parts[1] || '';
-                    const name = parts[3] || '';
-
-                    // Exclude VSCode containers (they start with vsc-)
-                    if (image.startsWith('vsc-')) {
-                        return false;
-                    }
-
-                    // Match official BirdNET-Go images or container name
-                    return image.startsWith(DOCKER_IMAGE) || image === CONTAINER_NAME || name === CONTAINER_NAME;
-                });
-
-                if (birdnetContainer) {
-                    const parts = birdnetContainer.split('|');
-                    const status = parts[2];
-                    const labels = parts.slice(4).join('|') || '';
-
-                    // Parse Docker Compose labels
-                    let isCompose = false;
-                    let composeProject = '';
-                    let composeService = '';
-                    let composeWorkingDir = '';
-
-                    if (labels.includes('com.docker.compose.project=')) {
-                        isCompose = true;
-                        // Extract compose project name
-                        const projectMatch = labels.match(/com.docker.compose.project=([^,]+)/);
-                        if (projectMatch) composeProject = projectMatch[1];
-
-                        // Extract compose service name
-                        const serviceMatch = labels.match(/com.docker.compose.service=([^,]+)/);
-                        if (serviceMatch) composeService = serviceMatch[1];
-
-                        // Extract working directory
-                        const workingDirMatch = labels.match(/com.docker.compose.project.working_dir=([^,]+)/);
-                        if (workingDirMatch) composeWorkingDir = workingDirMatch[1];
-                    }
-
-                    // Use health API result as primary indicator, fallback to Docker status
-                    setContainerStatus({
-                        exists: true,
-                        running: isActuallyRunning || status.startsWith('Up'),
-                        imagePresent,
-                        containerId: parts[0],
-                        status,
-                        isCompose,
-                        composeProject,
-                        composeService,
-                        composeWorkingDir,
-                    });
-                } else if (isActuallyRunning) {
-                    // BirdNET-Go is responding but we can't find a specific container
-                    // This means it's running as a native binary, not in Docker
-                    setContainerStatus({
-                        exists: false, // No container exists since it's a binary
-                        running: true,
-                        imagePresent,
-                        status: 'Running (native binary)',
-                    });
-                } else {
-                    setContainerStatus({
-                        exists: false,
-                        running: false,
-                        imagePresent,
-                    });
-                }
-            } else {
-                // No containers at all, but check if BirdNET-Go is running anyway
-                if (isActuallyRunning) {
-                    setContainerStatus({
-                        exists: false, // No container since it's a binary
-                        running: true,
-                        imagePresent,
-                        status: 'Running (native binary)',
-                    });
-                } else {
-                    setContainerStatus({
-                        exists: false,
-                        running: false,
-                        imagePresent,
-                    });
-                }
-            }
-        } catch (error) {
-            console.error('Error checking BirdNET-Go status:', error);
-            setContainerStatus({ exists: false, running: false, imagePresent: false });
-        }
+    const systemdStatus: SystemdStatus = {
+        exists: isSystemdKind,
+        running: isSystemdKind && deployment.running,
+        enabled: deployment.systemdEnabled ?? false,
+        ...(deployment.statusText !== undefined && { status: deployment.statusText }),
     };
 
     const fetchLogs = useCallback(async () => {
@@ -598,9 +408,8 @@ export const Application = () => {
 
     const refreshStatus = useCallback(async () => {
         setLoading(true);
-        await checkDockerStatus();
-        await checkSystemdStatus();
-        await checkBirdNetGoStatus();
+        const d = await detectDeployment(window.location.hostname);
+        setDeployment(d);
         await fetchHealthStatus();
         setLoading(false);
     }, [fetchHealthStatus]);
@@ -739,40 +548,13 @@ export const Application = () => {
         return _('BirdNET-Go container running');
     };
 
-    const startContainer = async () => {
-        if (!containerStatus.containerId) return;
+    const onStart = async () => { await driver.start(); await refreshStatus(); };
 
-        try {
-            await cockpit.spawn(['docker', 'start', containerStatus.containerId]);
-            await refreshStatus();
-        } catch (error) {
-            console.error('Error starting container:', error);
-        }
-    };
+    const onStop = async () => { await driver.stop(); await refreshStatus(); };
 
-    const stopContainer = async () => {
-        if (!containerStatus.containerId) return;
-
-        try {
-            await cockpit.spawn(['docker', 'stop', containerStatus.containerId]);
-            await refreshStatus();
-        } catch (error) {
-            console.error('Error stopping container:', error);
-        }
-    };
-
-    const restartContainer = async () => {
-        if (!containerStatus.containerId) return;
-
+    const onRestart = async () => {
         setRestarting(true);
-        try {
-            await cockpit.spawn(['docker', 'restart', containerStatus.containerId]);
-            await refreshStatus();
-        } catch (error) {
-            console.error('Error restarting container:', error);
-        } finally {
-            setRestarting(false);
-        }
+        try { await driver.restart(); await refreshStatus(); } finally { setRestarting(false); }
     };
 
     const createContainer = async () => {
@@ -805,37 +587,6 @@ export const Application = () => {
             await refreshStatus();
         } catch (error) {
             console.error('Error pulling image:', error);
-        }
-    };
-
-    // Systemd service controls
-    const startSystemdService = async () => {
-        try {
-            await cockpit.spawn(['systemctl', 'start', SERVICE_NAME], { superuser: 'try' });
-            await refreshStatus();
-        } catch (error) {
-            console.error('Error starting systemd service:', error);
-        }
-    };
-
-    const stopSystemdService = async () => {
-        try {
-            await cockpit.spawn(['systemctl', 'stop', SERVICE_NAME], { superuser: 'try' });
-            await refreshStatus();
-        } catch (error) {
-            console.error('Error stopping systemd service:', error);
-        }
-    };
-
-    const restartSystemdService = async () => {
-        setRestarting(true);
-        try {
-            await cockpit.spawn(['systemctl', 'restart', SERVICE_NAME], { superuser: 'try' });
-            await refreshStatus();
-        } catch (error) {
-            console.error('Error restarting systemd service:', error);
-        } finally {
-            setRestarting(false);
         }
     };
 
@@ -995,18 +746,18 @@ export const Application = () => {
                                     {systemdStatus.exists && (
                                         <FlexItem>
                                             {!systemdStatus.running && (
-                                                <Button variant="primary" onClick={startSystemdService}>
+                                                <Button variant="primary" onClick={onStart}>
                                                     Start Service
                                                 </Button>
                                             )}
                                             {systemdStatus.running && (
-                                                <Button variant="secondary" onClick={stopSystemdService}>
+                                                <Button variant="secondary" onClick={onStop}>
                                                     Stop Service
                                                 </Button>
                                             )}
                                             <Button
                                                 variant="secondary"
-                                                onClick={restartSystemdService}
+                                                onClick={onRestart}
                                                 isLoading={restarting}
                                                 style={{ marginLeft: '0.5rem' }}
                                             >
@@ -1031,21 +782,21 @@ export const Application = () => {
                                                 {containerStatus.exists && !containerStatus.running && (
                                                     <Button
                                                         variant="primary"
-                                                        onClick={startContainer}
+                                                        onClick={onStart}
                                                         isDisabled={!dockerStatus.running}
                                                     >
                                                         Start Container
                                                     </Button>
                                                 )}
                                                 {containerStatus.exists && containerStatus.running && (
-                                                    <Button variant="secondary" onClick={stopContainer}>
+                                                    <Button variant="secondary" onClick={onStop}>
                                                         Stop Container
                                                     </Button>
                                                 )}
                                                 {containerStatus.exists && (
                                                     <Button
                                                         variant="secondary"
-                                                        onClick={restartContainer}
+                                                        onClick={onRestart}
                                                         isDisabled={!dockerStatus.running || restarting}
                                                         isLoading={restarting}
                                                         style={{ marginLeft: '0.5rem' }}

--- a/src/deployment/capabilities.test.ts
+++ b/src/deployment/capabilities.test.ts
@@ -4,14 +4,23 @@ import { deriveCapabilities } from './capabilities';
 import type { Deployment } from './types';
 
 const dep = (over: Partial<Deployment>): Deployment => ({
-    kind: 'docker-standalone', runtime: 'docker', running: true, imagePresent: true,
-    hostPort: 8080, internalPort: 8080, dockerAvailable: true, dockerRunning: true, ...over,
+    kind: 'docker-standalone',
+    runtime: 'docker',
+    running: true,
+    imagePresent: true,
+    hostPort: 8080,
+    internalPort: 8080,
+    dockerAvailable: true,
+    dockerRunning: true,
+    ...over,
 });
 
 describe('deriveCapabilities', () => {
     it('docker-standalone on docker: auto change, docker-root privileged', () => {
         expect(deriveCapabilities(dep({ kind: 'docker-standalone', runtime: 'docker' }))).toEqual({
-            canChangePort: true, portChangeMode: 'auto', privilegedPortStrategy: 'docker-root',
+            canChangePort: true,
+            portChangeMode: 'auto',
+            privilegedPortStrategy: 'docker-root',
         });
     });
 
@@ -26,13 +35,16 @@ describe('deriveCapabilities', () => {
 
     it('native-systemd: guided-manual + setcap (native auto-edit deferred to a later milestone)', () => {
         expect(deriveCapabilities(dep({ kind: 'native-systemd', runtime: null }))).toEqual({
-            canChangePort: true, portChangeMode: 'guided-manual', privilegedPortStrategy: 'setcap',
+            canChangePort: true,
+            portChangeMode: 'guided-manual',
+            privilegedPortStrategy: 'setcap',
         });
     });
 
     it('native (bare): guided-manual, setcap', () => {
         expect(deriveCapabilities(dep({ kind: 'native', runtime: null }))).toMatchObject({
-            portChangeMode: 'guided-manual', privilegedPortStrategy: 'setcap',
+            portChangeMode: 'guided-manual',
+            privilegedPortStrategy: 'setcap',
         });
     });
 

--- a/src/deployment/capabilities.test.ts
+++ b/src/deployment/capabilities.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveCapabilities } from './capabilities';
+import type { Deployment } from './types';
+
+const dep = (over: Partial<Deployment>): Deployment => ({
+    kind: 'docker-standalone', runtime: 'docker', running: true, imagePresent: true,
+    hostPort: 8080, internalPort: 8080, dockerAvailable: true, dockerRunning: true, ...over,
+});
+
+describe('deriveCapabilities', () => {
+    it('docker-standalone on docker: auto change, docker-root privileged', () => {
+        expect(deriveCapabilities(dep({ kind: 'docker-standalone', runtime: 'docker' }))).toEqual({
+            canChangePort: true, portChangeMode: 'auto', privilegedPortStrategy: 'docker-root',
+        });
+    });
+
+    it('docker-standalone on podman: podman-sysctl privileged', () => {
+        expect(deriveCapabilities(dep({ runtime: 'podman' })).privilegedPortStrategy).toBe('podman-sysctl');
+    });
+
+    it('docker-compose and docker-systemd: guided-manual', () => {
+        expect(deriveCapabilities(dep({ kind: 'docker-compose' })).portChangeMode).toBe('guided-manual');
+        expect(deriveCapabilities(dep({ kind: 'docker-systemd' })).portChangeMode).toBe('guided-manual');
+    });
+
+    it('native-systemd: guided-manual + setcap (native auto-edit deferred to a later milestone)', () => {
+        expect(deriveCapabilities(dep({ kind: 'native-systemd', runtime: null }))).toEqual({
+            canChangePort: true, portChangeMode: 'guided-manual', privilegedPortStrategy: 'setcap',
+        });
+    });
+
+    it('native (bare): guided-manual, setcap', () => {
+        expect(deriveCapabilities(dep({ kind: 'native', runtime: null }))).toMatchObject({
+            portChangeMode: 'guided-manual', privilegedPortStrategy: 'setcap',
+        });
+    });
+
+    it('none: cannot change port', () => {
+        expect(deriveCapabilities(dep({ kind: 'none' })).canChangePort).toBe(false);
+    });
+});

--- a/src/deployment/capabilities.ts
+++ b/src/deployment/capabilities.ts
@@ -32,7 +32,11 @@ export const deriveCapabilities = (d: Deployment): DeploymentCapabilities => {
         case 'docker-compose':
             // Editing a systemd unit's ExecStart or a compose file in place is
             // fragile; guide the user instead. Auto is a later milestone.
-            return { canChangePort: true, portChangeMode: 'guided-manual', privilegedPortStrategy: dockerPrivileged(d) };
+            return {
+                canChangePort: true,
+                portChangeMode: 'guided-manual',
+                privilegedPortStrategy: dockerPrivileged(d),
+            };
         // Native auto-edit of the listen port is deferred until birdnet-go's
         // config key is verified (see M1). Until then both native shapes are
         // guided-manual: the plugin can restart the service but instructs the

--- a/src/deployment/capabilities.ts
+++ b/src/deployment/capabilities.ts
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Deployment, DeploymentCapabilities, PrivilegedPortStrategy } from './types';
+
+const dockerPrivileged = (d: Deployment): PrivilegedPortStrategy =>
+    d.runtime === 'podman' ? 'podman-sysctl' : 'docker-root';
+
+export const deriveCapabilities = (d: Deployment): DeploymentCapabilities => {
+    switch (d.kind) {
+        case 'docker-standalone':
+            // The only fully-automatic path: recreate the container with a new
+            // host port mapping. The container internal port stays 8080.
+            return { canChangePort: true, portChangeMode: 'auto', privilegedPortStrategy: dockerPrivileged(d) };
+        case 'docker-systemd':
+        case 'docker-compose':
+            // Editing a systemd unit's ExecStart or a compose file in place is
+            // fragile; guide the user instead. Auto is a later milestone.
+            return { canChangePort: true, portChangeMode: 'guided-manual', privilegedPortStrategy: dockerPrivileged(d) };
+        // Native auto-edit of the listen port is deferred until birdnet-go's
+        // config key is verified (see M1). Until then both native shapes are
+        // guided-manual: the plugin can restart the service but instructs the
+        // user where to change the port.
+        case 'native-systemd':
+        case 'native':
+            return { canChangePort: true, portChangeMode: 'guided-manual', privilegedPortStrategy: 'setcap' };
+        case 'none':
+        default:
+            return { canChangePort: false, portChangeMode: 'guided-manual', privilegedPortStrategy: 'none' };
+    }
+};

--- a/src/deployment/classify.test.ts
+++ b/src/deployment/classify.test.ts
@@ -24,7 +24,11 @@ describe('classifyDeployment', () => {
     });
 
     it('native-systemd when a systemd unit exists but no container', () => {
-        const d = classifyDeployment({ ...base, systemd: { exists: true, running: true, enabled: false }, healthRunning: true });
+        const d = classifyDeployment({
+            ...base,
+            systemd: { exists: true, running: true, enabled: false },
+            healthRunning: true,
+        });
         expect(d.kind).toBe('native-systemd');
         expect(d.internalPort).toBe(d.hostPort);
     });
@@ -32,7 +36,14 @@ describe('classifyDeployment', () => {
     it('docker-compose when a compose-labelled container exists and no systemd', () => {
         const d = classifyDeployment({
             ...base,
-            container: { id: 'c1', running: true, isCompose: true, composeProject: 'p', composeWorkingDir: '/srv/bng', hostPort: 9000 },
+            container: {
+                id: 'c1',
+                running: true,
+                isCompose: true,
+                composeProject: 'p',
+                composeWorkingDir: '/srv/bng',
+                hostPort: 9000,
+            },
         });
         expect(d.kind).toBe('docker-compose');
         expect(d.composeWorkingDir).toBe('/srv/bng');

--- a/src/deployment/classify.test.ts
+++ b/src/deployment/classify.test.ts
@@ -59,6 +59,21 @@ describe('classifyDeployment', () => {
         expect(d.systemdEnabled).toBe(true);
     });
 
+    it('native-systemd carries systemdStatusText from the systemd signal status', () => {
+        const d = classifyDeployment({
+            ...base,
+            systemd: { exists: true, running: true, enabled: false, status: 'active' },
+        });
+        expect(d.kind).toBe('native-systemd');
+        expect(d.systemdStatusText).toBe('active');
+    });
+
+    it('native (health-only, no container) sets statusText to "Running (native binary)"', () => {
+        const d = classifyDeployment({ runtime: null, imagePresent: false, healthRunning: true });
+        expect(d.kind).toBe('native');
+        expect(d.statusText).toBe('Running (native binary)');
+    });
+
     it('native when only the health API answers', () => {
         const d = classifyDeployment({ runtime: null, imagePresent: false, healthRunning: true });
         expect(d.kind).toBe('native');

--- a/src/deployment/classify.test.ts
+++ b/src/deployment/classify.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyDeployment } from './classify';
+import type { DetectionSignals } from './types';
+
+const base: DetectionSignals = {
+    runtime: 'docker',
+    imagePresent: true,
+    healthRunning: false,
+    docker: { available: true, running: true, version: 'Docker version 27' },
+};
+
+describe('classifyDeployment', () => {
+    it('docker-systemd when a systemd unit and a container both exist', () => {
+        const d = classifyDeployment({
+            ...base,
+            systemd: { exists: true, running: true, enabled: true },
+            container: { id: 'abc', running: true, isCompose: false, hostPort: 8080 },
+        });
+        expect(d.kind).toBe('docker-systemd');
+        expect(d.serviceName).toBe('birdnet-go.service');
+        expect(d.containerId).toBe('abc');
+        expect(d.running).toBe(true);
+    });
+
+    it('native-systemd when a systemd unit exists but no container', () => {
+        const d = classifyDeployment({ ...base, systemd: { exists: true, running: true, enabled: false }, healthRunning: true });
+        expect(d.kind).toBe('native-systemd');
+        expect(d.internalPort).toBe(d.hostPort);
+    });
+
+    it('docker-compose when a compose-labelled container exists and no systemd', () => {
+        const d = classifyDeployment({
+            ...base,
+            container: { id: 'c1', running: true, isCompose: true, composeProject: 'p', composeWorkingDir: '/srv/bng', hostPort: 9000 },
+        });
+        expect(d.kind).toBe('docker-compose');
+        expect(d.composeWorkingDir).toBe('/srv/bng');
+        expect(d.hostPort).toBe(9000);
+    });
+
+    it('docker-standalone for a plain container', () => {
+        const d = classifyDeployment({ ...base, container: { id: 'c2', running: true, isCompose: false } });
+        expect(d.kind).toBe('docker-standalone');
+        expect(d.hostPort).toBe(8080); // falls back to BIRDNET_PORT
+        expect(d.internalPort).toBe(8080);
+    });
+
+    it('carries the shim fields the legacy UI needs', () => {
+        const d = classifyDeployment({
+            ...base,
+            systemd: { exists: true, running: true, enabled: true },
+            container: { id: 'c3', running: true, isCompose: false, status: 'Up 2 hours' },
+        });
+        expect(d.dockerAvailable).toBe(true);
+        expect(d.dockerRunning).toBe(true);
+        expect(d.dockerVersion).toBe('Docker version 27');
+        expect(d.statusText).toBe('Up 2 hours');
+        expect(d.systemdEnabled).toBe(true);
+    });
+
+    it('native when only the health API answers', () => {
+        const d = classifyDeployment({ runtime: null, imagePresent: false, healthRunning: true });
+        expect(d.kind).toBe('native');
+        expect(d.running).toBe(true);
+    });
+
+    it('none when nothing is detected', () => {
+        const d = classifyDeployment({ runtime: 'docker', imagePresent: false, healthRunning: false });
+        expect(d.kind).toBe('none');
+        expect(d.running).toBe(false);
+    });
+});

--- a/src/deployment/classify.ts
+++ b/src/deployment/classify.ts
@@ -55,6 +55,8 @@ export const classifyDeployment = (s: DetectionSignals): Deployment => {
     if (container?.composeWorkingDir !== undefined) result.composeWorkingDir = container.composeWorkingDir;
     if (s.docker?.version !== undefined) result.dockerVersion = s.docker.version;
     if (container?.status !== undefined) result.statusText = container.status;
+    if (!hasContainer && s.healthRunning) result.statusText = 'Running (native binary)';
+    if (s.systemd?.status !== undefined) result.systemdStatusText = s.systemd.status;
     if (s.systemd?.enabled !== undefined) result.systemdEnabled = s.systemd.enabled;
 
     return result;

--- a/src/deployment/classify.ts
+++ b/src/deployment/classify.ts
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { BIRDNET_PORT, SERVICE_NAME } from '../config';
+import type { Deployment, DetectionSignals } from './types';
+
+export const classifyDeployment = (s: DetectionSignals): Deployment => {
+    const container = s.container;
+    const systemdExists = s.systemd?.exists ?? false;
+    const hasContainer = !!container;
+
+    let kind: Deployment['kind'];
+    if (systemdExists && hasContainer) kind = 'docker-systemd';
+    else if (systemdExists) kind = 'native-systemd';
+    else if (hasContainer && container!.isCompose) kind = 'docker-compose';
+    else if (hasContainer) kind = 'docker-standalone';
+    else if (s.healthRunning) kind = 'native';
+    else kind = 'none';
+
+    const running = (container?.running ?? false) || (s.systemd?.running ?? false) || s.healthRunning;
+    const hostPort = container?.hostPort ?? BIRDNET_PORT;
+    const internalPort = hasContainer ? BIRDNET_PORT : hostPort;
+
+    const result: Deployment = {
+        kind,
+        runtime: s.runtime,
+        running,
+        imagePresent: s.imagePresent,
+        hostPort,
+        internalPort,
+        dockerAvailable: s.docker?.available ?? false,
+        dockerRunning: s.docker?.running ?? false,
+    };
+
+    if (container?.id !== undefined) result.containerId = container.id;
+    if (systemdExists) result.serviceName = SERVICE_NAME;
+    if (container?.composeProject !== undefined) result.composeProject = container.composeProject;
+    if (container?.composeService !== undefined) result.composeService = container.composeService;
+    if (container?.composeWorkingDir !== undefined) result.composeWorkingDir = container.composeWorkingDir;
+    if (s.docker?.version !== undefined) result.dockerVersion = s.docker.version;
+    if (container?.status !== undefined) result.statusText = container.status;
+    if (s.systemd?.enabled !== undefined) result.systemdEnabled = s.systemd.enabled;
+
+    return result;
+};

--- a/src/deployment/detect.test.ts
+++ b/src/deployment/detect.test.ts
@@ -67,4 +67,21 @@ describe('detectDeployment', () => {
         expect(d.runtime).toBe('docker');
         expect(d.hostPort).toBe(8080);
     });
+
+    it('populates systemdStatusText from is-active output for a native-systemd deployment', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: false, out: '' };
+            if (cmd.includes('podman --version')) return { ok: false, out: '' };
+            if (cmd.includes('curl')) return { ok: false, out: '' };
+            if (cmd.includes('list-unit-files')) return { ok: true, out: 'birdnet-go.service enabled' };
+            if (cmd.includes('is-active')) return { ok: true, out: 'active' };
+            if (cmd.includes('is-enabled')) return { ok: true, out: 'enabled' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.kind).toBe('native-systemd');
+        expect(d.systemdStatusText).toBe('active');
+    });
 });

--- a/src/deployment/detect.test.ts
+++ b/src/deployment/detect.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { parseContainerLine, parseHostPort } from './detect';
+
+describe('parseContainerLine', () => {
+    it('parses a plain birdnet-go container line incl status', () => {
+        const c = parseContainerLine('abc123|ghcr.io/tphakala/birdnet-go:nightly|Up 2 hours|birdnet-go|');
+        // undefined-valued compose fields are ignored by toEqual
+        expect(c).toEqual({ id: 'abc123', running: true, isCompose: false, status: 'Up 2 hours' });
+    });
+
+    it('extracts compose project, service, and working dir from labels', () => {
+        const line =
+            'c1|ghcr.io/tphakala/birdnet-go:latest|Up|bng|com.docker.compose.project=bng,com.docker.compose.service=web,com.docker.compose.project.working_dir=/srv/bng';
+        const c = parseContainerLine(line);
+        expect(c).toMatchObject({ id: 'c1', isCompose: true, composeProject: 'bng', composeService: 'web', composeWorkingDir: '/srv/bng' });
+    });
+
+    it('ignores vscode dev containers', () => {
+        expect(parseContainerLine('x|vsc-abc|Up|vsc|')).toBeNull();
+    });
+
+    it('returns running:false for an exited container', () => {
+        expect(parseContainerLine('d|ghcr.io/tphakala/birdnet-go:nightly|Exited (0) 3m ago|birdnet-go|')?.running).toBe(false);
+    });
+});
+
+describe('parseHostPort', () => {
+    it('returns the host port mapped to the internal port', () => {
+        const inspect = JSON.stringify([{ HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '9000' }] } } }]);
+        expect(parseHostPort(inspect, 8080)).toBe(9000);
+    });
+
+    it('returns undefined when no mapping for the internal port exists', () => {
+        const inspect = JSON.stringify([{ HostConfig: { PortBindings: {} } }]);
+        expect(parseHostPort(inspect, 8080)).toBeUndefined();
+    });
+
+    it('returns undefined for unparseable input', () => {
+        expect(parseHostPort('not json', 8080)).toBeUndefined();
+    });
+});
+
+const probeMock = vi.fn();
+vi.mock('./exec', () => ({
+    exec: (...a: unknown[]) => probeMock(...a),
+    probe: (...a: unknown[]) => probeMock(...a),
+}));
+
+afterEach(() => probeMock.mockReset());
+
+describe('detectDeployment', () => {
+    it('classifies a running standalone docker deployment', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: true, out: 'Docker version 27' };
+            if (cmd.includes('images')) return { ok: true, out: 'ghcr.io/tphakala/birdnet-go:nightly' };
+            if (cmd.includes('curl')) return { ok: false, out: '' };
+            if (cmd.includes('ps -a')) return { ok: true, out: 'abc|ghcr.io/tphakala/birdnet-go:nightly|Up|birdnet-go|' };
+            if (cmd.includes('inspect')) return { ok: true, out: JSON.stringify([{ HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '8080' }] } } }]) };
+            if (cmd.includes('list-unit-files')) return { ok: true, out: '' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.kind).toBe('docker-standalone');
+        expect(d.runtime).toBe('docker');
+        expect(d.hostPort).toBe(8080);
+    });
+});

--- a/src/deployment/detect.test.ts
+++ b/src/deployment/detect.test.ts
@@ -13,7 +13,13 @@ describe('parseContainerLine', () => {
         const line =
             'c1|ghcr.io/tphakala/birdnet-go:latest|Up|bng|com.docker.compose.project=bng,com.docker.compose.service=web,com.docker.compose.project.working_dir=/srv/bng';
         const c = parseContainerLine(line);
-        expect(c).toMatchObject({ id: 'c1', isCompose: true, composeProject: 'bng', composeService: 'web', composeWorkingDir: '/srv/bng' });
+        expect(c).toMatchObject({
+            id: 'c1',
+            isCompose: true,
+            composeProject: 'bng',
+            composeService: 'web',
+            composeWorkingDir: '/srv/bng',
+        });
     });
 
     it('ignores vscode dev containers', () => {
@@ -21,7 +27,9 @@ describe('parseContainerLine', () => {
     });
 
     it('returns running:false for an exited container', () => {
-        expect(parseContainerLine('d|ghcr.io/tphakala/birdnet-go:nightly|Exited (0) 3m ago|birdnet-go|')?.running).toBe(false);
+        expect(parseContainerLine('d|ghcr.io/tphakala/birdnet-go:nightly|Exited (0) 3m ago|birdnet-go|')?.running).toBe(
+            false
+        );
     });
 });
 
@@ -57,8 +65,13 @@ describe('detectDeployment', () => {
             if (cmd.includes('docker --version')) return { ok: true, out: 'Docker version 27' };
             if (cmd.includes('images')) return { ok: true, out: 'ghcr.io/tphakala/birdnet-go:nightly' };
             if (cmd.includes('curl')) return { ok: false, out: '' };
-            if (cmd.includes('ps -a')) return { ok: true, out: 'abc|ghcr.io/tphakala/birdnet-go:nightly|Up|birdnet-go|' };
-            if (cmd.includes('inspect')) return { ok: true, out: JSON.stringify([{ HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '8080' }] } } }]) };
+            if (cmd.includes('ps -a'))
+                return { ok: true, out: 'abc|ghcr.io/tphakala/birdnet-go:nightly|Up|birdnet-go|' };
+            if (cmd.includes('inspect'))
+                return {
+                    ok: true,
+                    out: JSON.stringify([{ HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '8080' }] } } }]),
+                };
             if (cmd.includes('list-unit-files')) return { ok: true, out: '' };
             return { ok: false, out: '' };
         });

--- a/src/deployment/detect.ts
+++ b/src/deployment/detect.ts
@@ -119,7 +119,12 @@ export const detectDeployment = async (hostname: string): Promise<Deployment> =>
         const active = await probe(['systemctl', 'is-active', SERVICE_NAME]);
         const enabled = await probe(['systemctl', 'is-enabled', SERVICE_NAME]);
         const activeText = active.out || 'inactive';
-        systemd = { exists: true, running: active.out === 'active', enabled: enabled.out === 'enabled', status: activeText };
+        systemd = {
+            exists: true,
+            running: active.out === 'active',
+            enabled: enabled.out === 'enabled',
+            status: activeText,
+        };
     }
 
     // Build signals object, only including properties that are not undefined

--- a/src/deployment/detect.ts
+++ b/src/deployment/detect.ts
@@ -118,7 +118,8 @@ export const detectDeployment = async (hostname: string): Promise<Deployment> =>
     if (unitFiles.ok && unitFiles.out.includes(SERVICE_NAME)) {
         const active = await probe(['systemctl', 'is-active', SERVICE_NAME]);
         const enabled = await probe(['systemctl', 'is-enabled', SERVICE_NAME]);
-        systemd = { exists: true, running: active.out === 'active', enabled: enabled.out === 'enabled' };
+        const activeText = active.out || 'inactive';
+        systemd = { exists: true, running: active.out === 'active', enabled: enabled.out === 'enabled', status: activeText };
     }
 
     // Build signals object, only including properties that are not undefined

--- a/src/deployment/detect.ts
+++ b/src/deployment/detect.ts
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CONTAINER_NAME, DOCKER_IMAGE, SERVICE_NAME, getHealthUrl } from '../config';
+import { classifyDeployment } from './classify';
+import { probe } from './exec';
+import type { ContainerRuntime, DetectionSignals, Deployment } from './types';
+
+export const parseContainerLine = (line: string): DetectionSignals['container'] | null => {
+    const parts = line.split('|');
+    const id = parts[0];
+    const image = parts[1] || '';
+    const status = parts[2] || '';
+    const name = parts[3] || '';
+    const labels = parts.slice(4).join('|');
+    if (!id || image.startsWith('vsc-')) return null;
+    const isBirdnet = image.startsWith(DOCKER_IMAGE) || image === CONTAINER_NAME || name === CONTAINER_NAME;
+    if (!isBirdnet) return null;
+
+    const isCompose = labels.includes('com.docker.compose.project=');
+    const project = labels.match(/com\.docker\.compose\.project=([^,]+)/)?.[1];
+    const service = labels.match(/com\.docker\.compose\.service=([^,]+)/)?.[1];
+    const workingDir = labels.match(/com\.docker\.compose\.project\.working_dir=([^,]+)/)?.[1];
+
+    // Adapt for exactOptionalPropertyTypes: build base object, conditionally assign optionals
+    const c: DetectionSignals['container'] = {
+        id,
+        running: status.startsWith('Up'),
+        isCompose,
+        status,
+    };
+    if (project !== undefined) c.composeProject = project;
+    if (service !== undefined) c.composeService = service;
+    if (workingDir !== undefined) c.composeWorkingDir = workingDir;
+    return c;
+};
+
+export const parseHostPort = (inspectJson: string, internalPort: number): number | undefined => {
+    try {
+        const arr = JSON.parse(inspectJson);
+        const bindings = (Array.isArray(arr) ? arr[0] : arr)?.HostConfig?.PortBindings ?? {};
+        const hostPort = bindings[`${internalPort}/tcp`]?.[0]?.HostPort;
+        return hostPort ? parseInt(hostPort, 10) : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const detectDocker = async (): Promise<{ runtime: ContainerRuntime; docker: DetectionSignals['docker'] }> => {
+    const dv = await probe(['docker', '--version']);
+    if (dv.ok) {
+        const active = await probe(['systemctl', 'is-active', 'docker']);
+        return { runtime: 'docker', docker: { available: true, running: active.out === 'active', version: dv.out } };
+    }
+    const pv = await probe(['podman', '--version']);
+    if (pv.ok) return { runtime: 'podman', docker: { available: true, running: true, version: pv.out } };
+    return { runtime: null, docker: { available: false, running: false } };
+};
+
+export const detectDeployment = async (hostname: string): Promise<Deployment> => {
+    const { runtime, docker } = await detectDocker();
+    const bin = runtime ?? 'docker';
+
+    // image present?
+    const images = runtime ? (await probe([bin, 'images', '--format', '{{.Repository}}:{{.Tag}}'])).out : '';
+    const imagePresent = images.includes(DOCKER_IMAGE);
+
+    // health probe
+    const health = await probe(['curl', '-s', '-m', '2', getHealthUrl(hostname)]);
+    let healthRunning = false;
+    if (health.ok && health.out) {
+        try {
+            const status = (JSON.parse(health.out) as { status?: string }).status;
+            healthRunning = status === 'healthy' || status === 'degraded';
+        } catch {
+            healthRunning = false;
+        }
+    }
+
+    // container
+    let container: DetectionSignals['container'] | undefined;
+    if (runtime) {
+        const ps = await probe([bin, 'ps', '-a', '--format', '{{.ID}}|{{.Image}}|{{.Status}}|{{.Names}}|{{.Labels}}']);
+        for (const line of ps.out.split('\n')) {
+            const parsed = parseContainerLine(line);
+            if (parsed) {
+                container = parsed;
+                break;
+            }
+        }
+        if (container) {
+            const inspect = await probe([bin, 'inspect', container.id]);
+            // Adapt for exactOptionalPropertyTypes: capture to local, assign only if defined
+            const hp = parseHostPort(inspect.out, 8080);
+            if (hp !== undefined) container.hostPort = hp;
+        }
+    }
+
+    // systemd
+    const unitFiles = await probe(['systemctl', 'list-unit-files', '--no-pager', '--plain', SERVICE_NAME]);
+    let systemd: DetectionSignals['systemd'] | undefined;
+    if (unitFiles.ok && unitFiles.out.includes(SERVICE_NAME)) {
+        const active = await probe(['systemctl', 'is-active', SERVICE_NAME]);
+        const enabled = await probe(['systemctl', 'is-enabled', SERVICE_NAME]);
+        systemd = { exists: true, running: active.out === 'active', enabled: enabled.out === 'enabled' };
+    }
+
+    // Build signals object, only including properties that are not undefined
+    const signals: DetectionSignals = { runtime, imagePresent, healthRunning };
+    if (docker !== undefined) signals.docker = docker;
+    if (container !== undefined) signals.container = container;
+    if (systemd !== undefined) signals.systemd = systemd;
+
+    return classifyDeployment(signals);
+};

--- a/src/deployment/dockerDriver.test.ts
+++ b/src/deployment/dockerDriver.test.ts
@@ -7,11 +7,22 @@ import { DockerDriver } from './dockerDriver';
 import type { Deployment } from './types';
 
 const standalone: Deployment = {
-    kind: 'docker-standalone', runtime: 'docker', running: true, imagePresent: true,
-    containerId: 'abc', hostPort: 8080, internalPort: 8080,
-    dockerAvailable: true, dockerRunning: true,
+    kind: 'docker-standalone',
+    runtime: 'docker',
+    running: true,
+    imagePresent: true,
+    containerId: 'abc',
+    hostPort: 8080,
+    internalPort: 8080,
+    dockerAvailable: true,
+    dockerRunning: true,
 };
-const podmanSystemd: Deployment = { ...standalone, kind: 'docker-systemd', runtime: 'podman', serviceName: 'birdnet-go.service' };
+const podmanSystemd: Deployment = {
+    ...standalone,
+    kind: 'docker-systemd',
+    runtime: 'podman',
+    serviceName: 'birdnet-go.service',
+};
 
 afterEach(() => exec.mockClear());
 

--- a/src/deployment/dockerDriver.test.ts
+++ b/src/deployment/dockerDriver.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const exec = vi.fn().mockResolvedValue('');
+vi.mock('./exec', () => ({ exec: (...a: unknown[]) => exec(...a), probe: vi.fn() }));
+
+import { DockerDriver } from './dockerDriver';
+import type { Deployment } from './types';
+
+const standalone: Deployment = {
+    kind: 'docker-standalone', runtime: 'docker', running: true, imagePresent: true,
+    containerId: 'abc', hostPort: 8080, internalPort: 8080,
+    dockerAvailable: true, dockerRunning: true,
+};
+const podmanSystemd: Deployment = { ...standalone, kind: 'docker-systemd', runtime: 'podman', serviceName: 'birdnet-go.service' };
+
+afterEach(() => exec.mockClear());
+
+describe('DockerDriver lifecycle', () => {
+    it('restarts a standalone container via the container runtime', async () => {
+        await new DockerDriver(standalone).restart();
+        expect(exec).toHaveBeenCalledWith(['docker', 'restart', 'abc']);
+    });
+
+    it('uses podman binary when runtime is podman', async () => {
+        await new DockerDriver({ ...standalone, runtime: 'podman' }).start();
+        expect(exec).toHaveBeenCalledWith(['podman', 'start', 'abc']);
+    });
+
+    it('controls docker-systemd deployments through systemctl', async () => {
+        await new DockerDriver(podmanSystemd).restart();
+        expect(exec).toHaveBeenCalledWith(['systemctl', 'restart', 'birdnet-go.service'], { superuser: 'try' });
+    });
+
+    it('reports the current host port', async () => {
+        await expect(new DockerDriver(standalone).getHostPort()).resolves.toBe(8080);
+    });
+});

--- a/src/deployment/dockerDriver.ts
+++ b/src/deployment/dockerDriver.ts
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { deriveCapabilities } from './capabilities';
+import type { DeploymentDriver } from './driver';
+import { exec } from './exec';
+import type { Deployment, DeploymentCapabilities } from './types';
+
+export class DockerDriver implements DeploymentDriver {
+    constructor(private readonly d: Deployment) {}
+
+    private bin(): string {
+        return this.d.runtime === 'podman' ? 'podman' : 'docker';
+    }
+
+    async start(): Promise<void> {
+        if (this.d.serviceName) {
+            await exec(['systemctl', 'start', this.d.serviceName], { superuser: 'try' });
+        } else if (this.d.containerId) {
+            await exec([this.bin(), 'start', this.d.containerId]);
+        }
+    }
+
+    async stop(): Promise<void> {
+        if (this.d.serviceName) {
+            await exec(['systemctl', 'stop', this.d.serviceName], { superuser: 'try' });
+        } else if (this.d.containerId) {
+            await exec([this.bin(), 'stop', this.d.containerId]);
+        }
+    }
+
+    async restart(): Promise<void> {
+        if (this.d.serviceName) {
+            await exec(['systemctl', 'restart', this.d.serviceName], { superuser: 'try' });
+        } else if (this.d.containerId) {
+            await exec([this.bin(), 'restart', this.d.containerId]);
+        }
+    }
+
+    async getHostPort(): Promise<number> {
+        return this.d.hostPort;
+    }
+
+    getCapabilities(): DeploymentCapabilities {
+        return deriveCapabilities(this.d);
+    }
+}

--- a/src/deployment/driver.test.ts
+++ b/src/deployment/driver.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDriver } from './driver';
+import { DockerDriver } from './dockerDriver';
+import { NativeDriver } from './nativeDriver';
+import type { Deployment } from './types';
+
+const dep = (kind: Deployment['kind']): Deployment => ({
+    kind, runtime: 'docker', running: false, imagePresent: false,
+    dockerAvailable: false, dockerRunning: false,
+    hostPort: 8080, internalPort: 8080,
+});
+
+describe('getDriver', () => {
+    it('returns DockerDriver for docker kinds', () => {
+        expect(getDriver(dep('docker-standalone'))).toBeInstanceOf(DockerDriver);
+        expect(getDriver(dep('docker-systemd'))).toBeInstanceOf(DockerDriver);
+    });
+
+    it('returns NativeDriver for native kinds', () => {
+        expect(getDriver(dep('native-systemd'))).toBeInstanceOf(NativeDriver);
+        expect(getDriver(dep('native'))).toBeInstanceOf(NativeDriver);
+    });
+});

--- a/src/deployment/driver.test.ts
+++ b/src/deployment/driver.test.ts
@@ -6,9 +6,14 @@ import { NativeDriver } from './nativeDriver';
 import type { Deployment } from './types';
 
 const dep = (kind: Deployment['kind']): Deployment => ({
-    kind, runtime: 'docker', running: false, imagePresent: false,
-    dockerAvailable: false, dockerRunning: false,
-    hostPort: 8080, internalPort: 8080,
+    kind,
+    runtime: 'docker',
+    running: false,
+    imagePresent: false,
+    dockerAvailable: false,
+    dockerRunning: false,
+    hostPort: 8080,
+    internalPort: 8080,
 });
 
 describe('getDriver', () => {

--- a/src/deployment/driver.ts
+++ b/src/deployment/driver.ts
@@ -17,7 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type { DeploymentCapabilities } from './types';
+import { DockerDriver } from './dockerDriver';
+import { NativeDriver } from './nativeDriver';
+import type { Deployment, DeploymentCapabilities } from './types';
 
 export interface DeploymentDriver {
     start(): Promise<void>;
@@ -26,3 +28,6 @@ export interface DeploymentDriver {
     getHostPort(): Promise<number>;
     getCapabilities(): DeploymentCapabilities;
 }
+
+export const getDriver = (d: Deployment): DeploymentDriver =>
+    d.kind.startsWith('docker') ? new DockerDriver(d) : new NativeDriver(d);

--- a/src/deployment/driver.ts
+++ b/src/deployment/driver.ts
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { DeploymentCapabilities } from './types';
+
+export interface DeploymentDriver {
+    start(): Promise<void>;
+    stop(): Promise<void>;
+    restart(): Promise<void>;
+    getHostPort(): Promise<number>;
+    getCapabilities(): DeploymentCapabilities;
+}

--- a/src/deployment/exec.test.ts
+++ b/src/deployment/exec.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawn = vi.fn();
+vi.mock('cockpit', () => ({ default: { spawn: (...args: unknown[]) => spawn(...args) } }));
+
+import { exec, probe } from './exec';
+
+afterEach(() => spawn.mockReset());
+
+describe('exec', () => {
+    it('passes argv and superuser option through to cockpit.spawn and returns stdout', async () => {
+        spawn.mockResolvedValue('hello\n');
+        const out = await exec(['echo', 'hello'], { superuser: 'try' });
+        expect(out).toBe('hello\n');
+        expect(spawn).toHaveBeenCalledWith(['echo', 'hello'], { superuser: 'try', err: 'message' });
+    });
+
+    it('rejects when the underlying spawn rejects', async () => {
+        spawn.mockRejectedValue(new Error('boom'));
+        await expect(exec(['false'])).rejects.toThrow('boom');
+    });
+});
+
+describe('probe', () => {
+    it('returns ok:true with trimmed output on success', async () => {
+        spawn.mockResolvedValue('active\n');
+        expect(await probe(['systemctl', 'is-active', 'x'])).toEqual({ ok: true, out: 'active' });
+    });
+
+    it('returns ok:false with empty output when the command fails', async () => {
+        spawn.mockRejectedValue(new Error('inactive'));
+        expect(await probe(['systemctl', 'is-active', 'x'])).toEqual({ ok: false, out: '' });
+    });
+});

--- a/src/deployment/exec.ts
+++ b/src/deployment/exec.ts
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+export interface ExecOptions {
+    superuser?: 'try' | 'require';
+}
+
+/** Run a command on the host. Resolves stdout; rejects on non-zero exit. */
+export const exec = (argv: string[], opts: ExecOptions = {}): Promise<string> =>
+    cockpit.spawn(argv, { superuser: opts.superuser, err: 'message' }) as unknown as Promise<string>;
+
+/** Run a command expected to possibly fail (status probes). Never rejects. */
+export const probe = async (argv: string[], opts: ExecOptions = {}): Promise<{ ok: boolean; out: string }> => {
+    try {
+        const out = await exec(argv, opts);
+        return { ok: true, out: out.trim() };
+    } catch {
+        return { ok: false, out: '' };
+    }
+};

--- a/src/deployment/nativeDriver.test.ts
+++ b/src/deployment/nativeDriver.test.ts
@@ -7,14 +7,25 @@ import { NativeDriver } from './nativeDriver';
 import type { Deployment } from './types';
 
 const nativeSystemd: Deployment = {
-    kind: 'native-systemd', runtime: null, running: true, imagePresent: false,
-    dockerAvailable: false, dockerRunning: false,
-    serviceName: 'birdnet-go.service', hostPort: 8080, internalPort: 8080,
+    kind: 'native-systemd',
+    runtime: null,
+    running: true,
+    imagePresent: false,
+    dockerAvailable: false,
+    dockerRunning: false,
+    serviceName: 'birdnet-go.service',
+    hostPort: 8080,
+    internalPort: 8080,
 };
 const nativeBare: Deployment = {
-    kind: 'native', runtime: null, running: true, imagePresent: false,
-    dockerAvailable: false, dockerRunning: false,
-    hostPort: 8080, internalPort: 8080,
+    kind: 'native',
+    runtime: null,
+    running: true,
+    imagePresent: false,
+    dockerAvailable: false,
+    dockerRunning: false,
+    hostPort: 8080,
+    internalPort: 8080,
 };
 
 afterEach(() => exec.mockClear());

--- a/src/deployment/nativeDriver.test.ts
+++ b/src/deployment/nativeDriver.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const exec = vi.fn().mockResolvedValue('');
+vi.mock('./exec', () => ({ exec: (...a: unknown[]) => exec(...a), probe: vi.fn() }));
+
+import { NativeDriver } from './nativeDriver';
+import type { Deployment } from './types';
+
+const nativeSystemd: Deployment = {
+    kind: 'native-systemd', runtime: null, running: true, imagePresent: false,
+    dockerAvailable: false, dockerRunning: false,
+    serviceName: 'birdnet-go.service', hostPort: 8080, internalPort: 8080,
+};
+const nativeBare: Deployment = {
+    kind: 'native', runtime: null, running: true, imagePresent: false,
+    dockerAvailable: false, dockerRunning: false,
+    hostPort: 8080, internalPort: 8080,
+};
+
+afterEach(() => exec.mockClear());
+
+describe('NativeDriver lifecycle', () => {
+    it('restarts via systemctl when a unit exists', async () => {
+        await new NativeDriver(nativeSystemd).restart();
+        expect(exec).toHaveBeenCalledWith(['systemctl', 'restart', 'birdnet-go.service'], { superuser: 'try' });
+    });
+
+    it('does nothing on lifecycle calls for a bare native process', async () => {
+        await new NativeDriver(nativeBare).restart();
+        expect(exec).not.toHaveBeenCalled();
+    });
+});

--- a/src/deployment/nativeDriver.ts
+++ b/src/deployment/nativeDriver.ts
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { deriveCapabilities } from './capabilities';
+import type { DeploymentDriver } from './driver';
+import { exec } from './exec';
+import type { Deployment, DeploymentCapabilities } from './types';
+
+export class NativeDriver implements DeploymentDriver {
+    constructor(private readonly d: Deployment) {}
+
+    async start(): Promise<void> {
+        if (this.d.serviceName) await exec(['systemctl', 'start', this.d.serviceName], { superuser: 'try' });
+    }
+
+    async stop(): Promise<void> {
+        if (this.d.serviceName) await exec(['systemctl', 'stop', this.d.serviceName], { superuser: 'try' });
+    }
+
+    async restart(): Promise<void> {
+        if (this.d.serviceName) await exec(['systemctl', 'restart', this.d.serviceName], { superuser: 'try' });
+    }
+
+    async getHostPort(): Promise<number> {
+        return this.d.hostPort;
+    }
+
+    getCapabilities(): DeploymentCapabilities {
+        return deriveCapabilities(this.d);
+    }
+}

--- a/src/deployment/types.ts
+++ b/src/deployment/types.ts
@@ -47,6 +47,8 @@ export interface Deployment {
     dockerRunning: boolean;
     dockerVersion?: string;
     statusText?: string; // human-readable container/service status, e.g. "Up 2 hours"
+    // systemd active-state text ("active"/"inactive"/"failed") for the status grid
+    systemdStatusText?: string;
     systemdEnabled?: boolean;
 }
 
@@ -64,7 +66,7 @@ export interface DetectionSignals {
         hostPort?: number;
         status?: string;
     };
-    systemd?: { exists: boolean; running: boolean; enabled: boolean };
+    systemd?: { exists: boolean; running: boolean; enabled: boolean; status?: string };
     healthRunning: boolean;
 }
 

--- a/src/deployment/types.ts
+++ b/src/deployment/types.ts
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type DeploymentKind =
+    | 'docker-standalone'
+    | 'docker-compose'
+    | 'docker-systemd'
+    | 'native-systemd'
+    | 'native'
+    | 'none';
+
+export type ContainerRuntime = 'docker' | 'podman' | null;
+
+export interface Deployment {
+    kind: DeploymentKind;
+    runtime: ContainerRuntime;
+    running: boolean;
+    imagePresent: boolean;
+    containerId?: string;
+    serviceName?: string;
+    composeProject?: string;
+    composeService?: string;
+    composeWorkingDir?: string;
+    hostPort: number;
+    internalPort: number;
+    configPath?: string;
+    // Fields the existing app.tsx JSX still reads via a compatibility shim (M0 Task 7).
+    // These keep the Docker Status card, the Status details grid, and the upgrade
+    // routines working unchanged after detection is consolidated.
+    dockerAvailable: boolean;
+    dockerRunning: boolean;
+    dockerVersion?: string;
+    statusText?: string; // human-readable container/service status, e.g. "Up 2 hours"
+    systemdEnabled?: boolean;
+}
+
+export interface DetectionSignals {
+    runtime: ContainerRuntime;
+    imagePresent: boolean;
+    docker?: { available: boolean; running: boolean; version?: string };
+    container?: {
+        id: string;
+        running: boolean;
+        isCompose: boolean;
+        composeProject?: string;
+        composeService?: string;
+        composeWorkingDir?: string;
+        hostPort?: number;
+        status?: string;
+    };
+    systemd?: { exists: boolean; running: boolean; enabled: boolean };
+    healthRunning: boolean;
+}
+
+export type PortChangeMode = 'auto' | 'guided-manual';
+export type PrivilegedPortStrategy = 'docker-root' | 'podman-sysctl' | 'setcap' | 'none';
+
+export interface DeploymentCapabilities {
+    canChangePort: boolean;
+    portChangeMode: PortChangeMode;
+    privilegedPortStrategy: PrivilegedPortStrategy;
+}


### PR DESCRIPTION
## Summary

Introduces a typed deployment-abstraction service layer (`src/deployment/`) that hides BirdNET-Go's deployment shapes (standalone Docker, Docker Compose, Docker-via-systemd, native-via-systemd, native-bare) behind a uniform driver, and rewires `src/app.tsx` detection and lifecycle onto it with no visible behavior change. This is the foundation for later port-management and version-management work; no user-facing feature ships in this PR.

The UI never calls `cockpit.spawn` for deployment concerns directly anymore: a single thin `exec`/`probe` wrapper is the only module that imports `cockpit` for process exec.

### What's in the layer

- `exec.ts` - typed `exec`/`probe` over `cockpit.spawn` (the only cockpit-exec boundary).
- `types.ts` - `Deployment` discriminated union, `DetectionSignals`, capability types.
- `classify.ts` - pure `classifyDeployment` (raw signals to a typed `Deployment`).
- `detect.ts` - `detectDeployment(hostname)` plus pure `parseContainerLine` / `parseHostPort`.
- `capabilities.ts` - pure `deriveCapabilities` (what each deployment can do).
- `driver.ts` / `dockerDriver.ts` / `nativeDriver.ts` - `DeploymentDriver` interface, Docker and Native lifecycle drivers, and the `getDriver` factory.
- `app.tsx` - detection and the start/stop/restart buttons now route through the driver; the three old status `useState`s collapse into one `deployment` state plus derived compatibility shims, so the existing Docker/Status/Version/logs UI renders identically.

### Behavior parity

M0's bar is no visible behavior change. Detection consolidation preserved the status-grid text for every kind (container status for Docker, `systemctl is-active` text for systemd units, "Running (native binary)" for bare-native) and kept lifecycle error logging on the start/stop/restart handlers.

## Commits

8 commits, built test-first task by task (exec, types/classifier, detect, capabilities/driver, DockerDriver, NativeDriver/factory, app.tsx rewire), plus a parity fix.

## Test Plan

- [x] `npm run eslint` clean
- [x] `npm run typecheck` clean (`strict` + `exactOptionalPropertyTypes`)
- [x] `npx vitest run` green (149 tests, incl. the `app.tsx` render regression)
- [x] `npm run build` succeeds
- [ ] CI: Lint & Build, CodeQL, Dependency Review

## Known limitation (follow-up, not in scope here)

Runtime detection now recognizes podman as well as docker. On a podman-only host the not-yet-migrated `Create Container` / `Pull Image` / `Upgrade` actions still shell out to `docker` and would fail; lifecycle (start/stop/restart) works correctly because the driver selects the right binary. Migrating those install/version actions onto the driver is tracked for the next milestone.