### PR TITLE
M1: port management with apply-verify-rollback safety net

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -51,6 +51,7 @@ import type { ContainerStatus, DockerStatus, HealthStatus, LogEntry, SystemdStat
 import { detectDeployment } from './deployment/detect';
 import { getDriver } from './deployment/driver';
 import type { Deployment } from './deployment/types';
+import { PortCard } from './components/PortCard';
 import {
     capitalize,
     filterLogs,
@@ -1228,6 +1229,14 @@ export const Application = () => {
                                 )}
                             </CardBody>
                         </Card>
+                    </GridItem>
+
+                    <GridItem xl={6} lg={6} md={12}>
+                        <PortCard
+                            deployment={deployment}
+                            hostname={window.location.hostname}
+                            onChanged={refreshStatus}
+                        />
                     </GridItem>
 
                     <GridItem span={12}>

--- a/src/components/PortCard.test.tsx
+++ b/src/components/PortCard.test.tsx
@@ -49,4 +49,10 @@ describe('PortCard', () => {
         const applyButton = await screen.findByRole('button', { name: /apply/i });
         expect(applyButton.hasAttribute('disabled')).toBe(true);
     });
+
+    it('disables apply when the entered port equals the current port', async () => {
+        render(<PortCard deployment={dep({})} hostname="localhost" onChanged={() => {}} />);
+        const applyButton = await screen.findByRole('button', { name: /apply/i });
+        expect(applyButton.hasAttribute('disabled')).toBe(true);
+    });
 });

--- a/src/components/PortCard.test.tsx
+++ b/src/components/PortCard.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { PortCard } from './PortCard';
+import type { Deployment } from '../deployment/types';
+
+afterEach(cleanup);
+
+const dep = (over: Partial<Deployment>): Deployment => ({
+    kind: 'docker-standalone',
+    runtime: 'docker',
+    running: true,
+    imagePresent: true,
+    dockerAvailable: true,
+    dockerRunning: true,
+    containerId: 'abc',
+    hostPort: 8080,
+    internalPort: 8080,
+    ...over,
+});
+
+describe('PortCard', () => {
+    it('shows the current port', async () => {
+        render(<PortCard deployment={dep({})} hostname="localhost" onChanged={() => {}} />);
+        // Use findAllByText because "8080" appears in both the current-port paragraph
+        // and the quick-set button, making findByText (single-match) throw.
+        const matches = await screen.findAllByText(/8080/);
+        expect(matches.length).toBeGreaterThan(0);
+    });
+
+    it('shows a guided-manual notice for compose deployments', async () => {
+        render(
+            <PortCard
+                deployment={dep({ kind: 'docker-compose', composeWorkingDir: '/srv/bng' })}
+                hostname="localhost"
+                onChanged={() => {}}
+            />
+        );
+        expect(await screen.findByText(/compose/i)).toBeTruthy();
+    });
+
+    it('disables apply when the deployment cannot change its port', async () => {
+        render(
+            <PortCard deployment={dep({ kind: 'none', running: false })} hostname="localhost" onChanged={() => {}} />
+        );
+        const applyButton = await screen.findByRole('button', { name: /apply/i });
+        expect(applyButton.hasAttribute('disabled')).toBe(true);
+    });
+});

--- a/src/components/PortCard.tsx
+++ b/src/components/PortCard.tsx
@@ -129,7 +129,7 @@ export const PortCard: React.FC<PortCardProps> = ({ deployment, hostname, onChan
                             variant="primary"
                             onClick={apply}
                             isLoading={busy}
-                            isDisabled={!caps.canChangePort || !valid || busy}
+                            isDisabled={!caps.canChangePort || !valid || busy || port === deployment.hostPort}
                         >
                             {_('Apply')}
                         </Button>

--- a/src/components/PortCard.tsx
+++ b/src/components/PortCard.tsx
@@ -45,19 +45,29 @@ export const PortCard: React.FC<PortCardProps> = ({ deployment, hostname, onChan
     const [busy, setBusy] = useState(false);
     const [result, setResult] = useState<ApplyResult | null>(null);
 
-    const port = parseInt(value, 10);
-    const valid = validatePort(port);
+    const port = Number(value);
+    const valid = /^\d+$/.test(value) && validatePort(port);
 
-    useEffect(() => {
-        const t = setTimeout(() => setValue(String(deployment.hostPort)), 0);
-        return () => clearTimeout(t);
-    }, [deployment.hostPort]);
+    // When the detected port changes, reset the input to it (adjust-state-during-render).
+    const [prevHostPort, setPrevHostPort] = useState(deployment.hostPort);
+    if (deployment.hostPort !== prevHostPort) {
+        setPrevHostPort(deployment.hostPort);
+        setValue(String(deployment.hostPort));
+    }
 
+    // When the typed value changes, clear any stale availability result immediately.
+    // IMPORTANT: compare the STRING `value`, not the numeric `port`. `port` can be NaN
+    // (e.g. empty/garbage input) and `NaN !== NaN` is always true, which would loop forever.
+    const [prevValue, setPrevValue] = useState(value);
+    if (value !== prevValue) {
+        setPrevValue(value);
+        setAvailable(null);
+    }
+
+    // Debounced availability check (valid && different from current). Only setState here
+    // is inside the timer callback, so react-hooks/set-state-in-effect does not fire.
     useEffect(() => {
-        if (!valid || port === deployment.hostPort) {
-            const t = setTimeout(() => setAvailable(null), 0);
-            return () => clearTimeout(t);
-        }
+        if (!valid || port === deployment.hostPort) return;
         let cancelled = false;
         const t = setTimeout(() => {
             checkPortAvailable(port)

--- a/src/components/PortCard.tsx
+++ b/src/components/PortCard.tsx
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useEffect, useState } from 'react';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core/dist/esm/components/Card/index.js';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button/index.js';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput/index.js';
+import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/index.js';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex/index.js';
+
+import cockpit from 'cockpit';
+import { getDriver } from '../deployment/driver';
+import { checkPortAvailable, isPrivilegedPort, validatePort } from '../deployment/ports';
+import { defaultSafeSetPortDeps, safeSetPort, type ApplyResult } from '../deployment/safeApply';
+import type { Deployment } from '../deployment/types';
+
+const _ = cockpit.gettext;
+
+export interface PortCardProps {
+    deployment: Deployment;
+    hostname: string;
+    onChanged: () => void;
+}
+
+export const PortCard: React.FC<PortCardProps> = ({ deployment, hostname, onChanged }) => {
+    const driver = getDriver(deployment);
+    const caps = driver.getCapabilities();
+    const [value, setValue] = useState(String(deployment.hostPort));
+    const [available, setAvailable] = useState<boolean | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [result, setResult] = useState<ApplyResult | null>(null);
+
+    const port = parseInt(value, 10);
+    const valid = validatePort(port);
+
+    useEffect(() => {
+        const t = setTimeout(() => setValue(String(deployment.hostPort)), 0);
+        return () => clearTimeout(t);
+    }, [deployment.hostPort]);
+
+    useEffect(() => {
+        if (!valid || port === deployment.hostPort) {
+            const t = setTimeout(() => setAvailable(null), 0);
+            return () => clearTimeout(t);
+        }
+        let cancelled = false;
+        const t = setTimeout(() => {
+            checkPortAvailable(port)
+                .then(r => !cancelled && setAvailable(r.free))
+                .catch(() => !cancelled && setAvailable(null));
+        }, 400);
+        return () => {
+            cancelled = true;
+            clearTimeout(t);
+        };
+    }, [port, valid, deployment.hostPort]);
+
+    const apply = async () => {
+        setBusy(true);
+        setResult(null);
+        try {
+            const r = await safeSetPort(driver, deployment, port, hostname, defaultSafeSetPortDeps);
+            setResult(r);
+            if (r.kind === 'applied') onChanged();
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <Card>
+            <CardTitle>{_('Network & Port')}</CardTitle>
+            <CardBody>
+                <p>
+                    <strong>{_('Current port:')}</strong> {deployment.hostPort}
+                </p>
+
+                {caps.portChangeMode === 'guided-manual' && (
+                    <Alert
+                        variant="info"
+                        isInline
+                        isPlain
+                        title={
+                            deployment.kind === 'docker-compose'
+                                ? _('This Docker Compose deployment needs a manual port change')
+                                : _('This deployment needs a manual port change')
+                        }
+                        className="pf-v6-u-mb-md"
+                    />
+                )}
+
+                <Flex className="pf-v6-u-gap-sm pf-v6-u-align-items-center">
+                    <FlexItem>
+                        <TextInput
+                            aria-label={_('New port')}
+                            value={value}
+                            type="number"
+                            onChange={(_e, v) => setValue(v)}
+                        />
+                    </FlexItem>
+                    <FlexItem>
+                        <Button variant="secondary" onClick={() => setValue('80')}>
+                            80
+                        </Button>{' '}
+                        <Button variant="secondary" onClick={() => setValue('443')}>
+                            443
+                        </Button>{' '}
+                        <Button variant="secondary" onClick={() => setValue('8080')}>
+                            8080
+                        </Button>
+                    </FlexItem>
+                    <FlexItem>
+                        <Button
+                            variant="primary"
+                            onClick={apply}
+                            isLoading={busy}
+                            isDisabled={!caps.canChangePort || !valid || busy}
+                        >
+                            {_('Apply')}
+                        </Button>
+                    </FlexItem>
+                </Flex>
+
+                {valid && isPrivilegedPort(port) && (
+                    <Alert
+                        variant="warning"
+                        isInline
+                        isPlain
+                        className="pf-v6-u-mt-sm"
+                        title={_('Privileged port (below 1024) may require extra host permissions')}
+                    />
+                )}
+                {available === false && (
+                    <Alert
+                        variant="warning"
+                        isInline
+                        isPlain
+                        className="pf-v6-u-mt-sm"
+                        title={_('That port is already in use')}
+                    />
+                )}
+                {available === true && (
+                    <Alert
+                        variant="success"
+                        isInline
+                        isPlain
+                        className="pf-v6-u-mt-sm"
+                        title={_('Port is available')}
+                    />
+                )}
+
+                {result && result.kind === 'applied' && (
+                    <Alert
+                        variant="success"
+                        isInline
+                        className="pf-v6-u-mt-md"
+                        title={_('Port changed and service is healthy')}
+                    />
+                )}
+                {result && result.kind === 'rolled-back' && (
+                    <Alert variant="danger" isInline className="pf-v6-u-mt-md" title={result.reason} />
+                )}
+                {result && result.kind === 'precheck-failed' && (
+                    <Alert variant="warning" isInline className="pf-v6-u-mt-md" title={result.reason} />
+                )}
+                {result && result.kind === 'guided-manual' && (
+                    <Alert variant="info" isInline className="pf-v6-u-mt-md" title={_('Manual steps required')}>
+                        {result.instructions}
+                    </Alert>
+                )}
+            </CardBody>
+        </Card>
+    );
+};

--- a/src/deployment/dockerDriver.test.ts
+++ b/src/deployment/dockerDriver.test.ts
@@ -3,6 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const exec = vi.fn().mockResolvedValue('');
 vi.mock('./exec', () => ({ exec: (...a: unknown[]) => exec(...a), probe: vi.fn() }));
 
+const recreate = vi.fn().mockResolvedValue(undefined);
+vi.mock('./recreate', () => ({ recreateContainer: (...a: unknown[]) => recreate(...a) }));
+
 import { DockerDriver } from './dockerDriver';
 import type { Deployment } from './types';
 
@@ -24,7 +27,10 @@ const podmanSystemd: Deployment = {
     serviceName: 'birdnet-go.service',
 };
 
-afterEach(() => exec.mockClear());
+afterEach(() => {
+    exec.mockClear();
+    recreate.mockClear();
+});
 
 describe('DockerDriver lifecycle', () => {
     it('restarts a standalone container via the container runtime', async () => {
@@ -44,5 +50,26 @@ describe('DockerDriver lifecycle', () => {
 
     it('reports the current host port', async () => {
         await expect(new DockerDriver(standalone).getHostPort()).resolves.toBe(8080);
+    });
+});
+
+describe('DockerDriver.setHostPort', () => {
+    it('recreates a standalone container with the new host port', async () => {
+        const r = await new DockerDriver(standalone).setHostPort(443);
+        expect(recreate).toHaveBeenCalledWith('docker', 'abc', { hostPort: 443, internalPort: 8080 });
+        expect(r).toEqual({ kind: 'applied' });
+    });
+
+    it('returns guided-manual instructions for a docker-systemd deployment', async () => {
+        const r = await new DockerDriver(podmanSystemd).setHostPort(443);
+        expect(r.kind).toBe('guided-manual');
+        if (r.kind === 'guided-manual') expect(r.instructions).toContain('birdnet-go.service');
+        expect(recreate).not.toHaveBeenCalled();
+    });
+
+    it('returns guided-manual instructions referencing the compose dir for compose', async () => {
+        const compose: Deployment = { ...standalone, kind: 'docker-compose', composeWorkingDir: '/srv/bng' };
+        const r = await new DockerDriver(compose).setHostPort(443);
+        if (r.kind === 'guided-manual') expect(r.instructions).toContain('/srv/bng');
     });
 });

--- a/src/deployment/dockerDriver.test.ts
+++ b/src/deployment/dockerDriver.test.ts
@@ -70,6 +70,24 @@ describe('DockerDriver.setHostPort', () => {
     it('returns guided-manual instructions referencing the compose dir for compose', async () => {
         const compose: Deployment = { ...standalone, kind: 'docker-compose', composeWorkingDir: '/srv/bng' };
         const r = await new DockerDriver(compose).setHostPort(443);
+        expect(r.kind).toBe('guided-manual');
         if (r.kind === 'guided-manual') expect(r.instructions).toContain('/srv/bng');
+    });
+
+    it('returns guided-manual instructions for a standalone deployment missing its container id', async () => {
+        const orphan: Deployment = {
+            kind: 'docker-standalone',
+            runtime: 'docker',
+            running: true,
+            imagePresent: true,
+            hostPort: 8080,
+            internalPort: 8080,
+            dockerAvailable: true,
+            dockerRunning: true,
+        };
+        const r = await new DockerDriver(orphan).setHostPort(443);
+        expect(r.kind).toBe('guided-manual');
+        if (r.kind === 'guided-manual') expect(r.instructions).not.toContain('undefined');
+        expect(recreate).not.toHaveBeenCalled();
     });
 });

--- a/src/deployment/dockerDriver.ts
+++ b/src/deployment/dockerDriver.ts
@@ -79,12 +79,18 @@ export class DockerDriver implements DeploymentDriver {
                     `(e.g. "${port}:8080"), then run: docker compose up -d`,
             };
         }
-        // docker-systemd
+        if (this.d.kind === 'docker-systemd') {
+            return {
+                kind: 'guided-manual',
+                instructions:
+                    `Edit the ExecStart line of ${this.d.serviceName} to map host port ${port} (e.g. -p ${port}:8080), ` +
+                    `then run: systemctl daemon-reload && systemctl restart ${this.d.serviceName}`,
+            };
+        }
+        // Fallback: e.g. a standalone deployment with no container id, or an unexpected kind.
         return {
             kind: 'guided-manual',
-            instructions:
-                `Edit the ExecStart line of ${this.d.serviceName} to map host port ${port} (e.g. -p ${port}:8080), ` +
-                `then run: systemctl daemon-reload && systemctl restart ${this.d.serviceName}`,
+            instructions: `Could not determine how to change the port automatically for this deployment. Recreate the container with the new host mapping (for example -p ${port}:8080).`,
         };
     }
 }

--- a/src/deployment/dockerDriver.ts
+++ b/src/deployment/dockerDriver.ts
@@ -18,8 +18,9 @@
  */
 
 import { deriveCapabilities } from './capabilities';
-import type { DeploymentDriver } from './driver';
+import type { DeploymentDriver, PortChangeResult } from './driver';
 import { exec } from './exec';
+import { recreateContainer } from './recreate';
 import type { Deployment, DeploymentCapabilities } from './types';
 
 export class DockerDriver implements DeploymentDriver {
@@ -59,5 +60,31 @@ export class DockerDriver implements DeploymentDriver {
 
     getCapabilities(): DeploymentCapabilities {
         return deriveCapabilities(this.d);
+    }
+
+    async setHostPort(port: number): Promise<PortChangeResult> {
+        if (this.d.kind === 'docker-standalone' && this.d.containerId) {
+            await recreateContainer(this.bin(), this.d.containerId, {
+                hostPort: port,
+                internalPort: this.d.internalPort,
+            });
+            return { kind: 'applied' };
+        }
+        if (this.d.kind === 'docker-compose') {
+            const dir = this.d.composeWorkingDir || 'your compose project directory';
+            return {
+                kind: 'guided-manual',
+                instructions:
+                    `In ${dir}, set the host side of the birdnet-go service ports mapping to ${port} ` +
+                    `(e.g. "${port}:8080"), then run: docker compose up -d`,
+            };
+        }
+        // docker-systemd
+        return {
+            kind: 'guided-manual',
+            instructions:
+                `Edit the ExecStart line of ${this.d.serviceName} to map host port ${port} (e.g. -p ${port}:8080), ` +
+                `then run: systemctl daemon-reload && systemctl restart ${this.d.serviceName}`,
+        };
     }
 }

--- a/src/deployment/driver.ts
+++ b/src/deployment/driver.ts
@@ -21,12 +21,15 @@ import { DockerDriver } from './dockerDriver';
 import { NativeDriver } from './nativeDriver';
 import type { Deployment, DeploymentCapabilities } from './types';
 
+export type PortChangeResult = { kind: 'applied' } | { kind: 'guided-manual'; instructions: string };
+
 export interface DeploymentDriver {
     start(): Promise<void>;
     stop(): Promise<void>;
     restart(): Promise<void>;
     getHostPort(): Promise<number>;
     getCapabilities(): DeploymentCapabilities;
+    setHostPort(port: number): Promise<PortChangeResult>;
 }
 
 export const getDriver = (d: Deployment): DeploymentDriver =>

--- a/src/deployment/nativeDriver.test.ts
+++ b/src/deployment/nativeDriver.test.ts
@@ -41,3 +41,11 @@ describe('NativeDriver lifecycle', () => {
         expect(exec).not.toHaveBeenCalled();
     });
 });
+
+describe('NativeDriver.setHostPort', () => {
+    it('returns guided-manual instructions and does not exec', async () => {
+        const r = await new NativeDriver(nativeSystemd).setHostPort(443);
+        expect(r.kind).toBe('guided-manual');
+        expect(exec).not.toHaveBeenCalled();
+    });
+});

--- a/src/deployment/nativeDriver.test.ts
+++ b/src/deployment/nativeDriver.test.ts
@@ -48,4 +48,11 @@ describe('NativeDriver.setHostPort', () => {
         expect(r.kind).toBe('guided-manual');
         expect(exec).not.toHaveBeenCalled();
     });
+
+    it('includes a setcap hint for privileged ports and does not exec', async () => {
+        const r = await new NativeDriver(nativeSystemd).setHostPort(80);
+        expect(r.kind).toBe('guided-manual');
+        if (r.kind === 'guided-manual') expect(r.instructions).toContain('cap_net_bind_service');
+        expect(exec).not.toHaveBeenCalled();
+    });
 });

--- a/src/deployment/nativeDriver.ts
+++ b/src/deployment/nativeDriver.ts
@@ -18,7 +18,7 @@
  */
 
 import { deriveCapabilities } from './capabilities';
-import type { DeploymentDriver } from './driver';
+import type { DeploymentDriver, PortChangeResult } from './driver';
 import { exec } from './exec';
 import type { Deployment, DeploymentCapabilities } from './types';
 
@@ -43,5 +43,20 @@ export class NativeDriver implements DeploymentDriver {
 
     getCapabilities(): DeploymentCapabilities {
         return deriveCapabilities(this.d);
+    }
+
+    async setHostPort(port: number): Promise<PortChangeResult> {
+        const restart = this.d.serviceName
+            ? `then restart it from this page or run: systemctl restart ${this.d.serviceName}`
+            : 'then restart the birdnet-go process';
+        return {
+            kind: 'guided-manual',
+            instructions:
+                `Set the web server port to ${port} in the BirdNET-Go configuration, ${restart}. ` +
+                (port < 1024
+                    ? `Because ${port} is a privileged port, also grant the binary permission with: ` +
+                      `setcap 'cap_net_bind_service=+ep' /path/to/birdnet-go`
+                    : ''),
+        };
     }
 }

--- a/src/deployment/ports.test.ts
+++ b/src/deployment/ports.test.ts
@@ -44,6 +44,9 @@ describe('parseListeningPorts', () => {
     it('returns an empty set for empty input', () => {
         expect(parseListeningPorts('')).toEqual(new Set());
     });
+    it('extracts the local port even when ss emits a leading Netid column', () => {
+        expect(parseListeningPorts('tcp LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:*')).toEqual(new Set([8080]));
+    });
 });
 
 describe('checkPortAvailable', () => {

--- a/src/deployment/ports.test.ts
+++ b/src/deployment/ports.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const probe = vi.fn();
+vi.mock('./exec', () => ({ probe: (...a: unknown[]) => probe(...a), exec: vi.fn() }));
+
+import { checkPortAvailable, isPrivilegedPort, parseListeningPorts, validatePort } from './ports';
+
+afterEach(() => probe.mockReset());
+
+describe('validatePort', () => {
+    it('accepts 1..65535 integers', () => {
+        expect(validatePort(80)).toBe(true);
+        expect(validatePort(65535)).toBe(true);
+    });
+    it('rejects out-of-range and non-integers', () => {
+        expect(validatePort(0)).toBe(false);
+        expect(validatePort(70000)).toBe(false);
+        expect(validatePort(80.5)).toBe(false);
+        expect(validatePort(NaN)).toBe(false);
+    });
+});
+
+describe('isPrivilegedPort', () => {
+    it('is true below 1024', () => {
+        expect(isPrivilegedPort(80)).toBe(true);
+        expect(isPrivilegedPort(443)).toBe(true);
+        expect(isPrivilegedPort(1023)).toBe(true);
+    });
+    it('is false at and above 1024', () => {
+        expect(isPrivilegedPort(1024)).toBe(false);
+        expect(isPrivilegedPort(8080)).toBe(false);
+    });
+});
+
+describe('parseListeningPorts', () => {
+    it('extracts local ports from ss -H -ltn output (ipv4 and ipv6)', () => {
+        const out = [
+            'LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:*',
+            'LISTEN 0 128 127.0.0.1:9090 0.0.0.0:*',
+            'LISTEN 0 4096 [::]:22 [::]:*',
+        ].join('\n');
+        expect(parseListeningPorts(out)).toEqual(new Set([8080, 9090, 22]));
+    });
+    it('returns an empty set for empty input', () => {
+        expect(parseListeningPorts('')).toEqual(new Set());
+    });
+});
+
+describe('checkPortAvailable', () => {
+    it('reports free when no listener is on the port', async () => {
+        probe.mockResolvedValue({ ok: true, out: 'LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:*' });
+        expect(await checkPortAvailable(443)).toEqual({ free: true });
+    });
+    it('reports not free when a listener exists', async () => {
+        probe.mockResolvedValue({ ok: true, out: 'LISTEN 0 128 127.0.0.1:9090 0.0.0.0:*' });
+        expect(await checkPortAvailable(9090)).toEqual({ free: false });
+    });
+    it('assumes free when ss cannot be run', async () => {
+        probe.mockResolvedValue({ ok: false, out: '' });
+        expect(await checkPortAvailable(80)).toEqual({ free: true });
+    });
+});

--- a/src/deployment/ports.ts
+++ b/src/deployment/ports.ts
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { probe } from './exec';
+
+export const validatePort = (p: number): boolean => Number.isInteger(p) && p >= 1 && p <= 65535;
+
+export const isPrivilegedPort = (p: number): boolean => p < 1024;
+
+/** Parse `ss -H -ltn` output to the set of locally listening ports. */
+export const parseListeningPorts = (ssOutput: string): Set<number> => {
+    const ports = new Set<number>();
+    for (const line of ssOutput.split('\n')) {
+        // local address is the 4th whitespace-separated column, e.g. 0.0.0.0:8080 or [::]:22
+        const local = line.trim().split(/\s+/)[3];
+        if (!local) continue;
+        const port = parseInt(local.slice(local.lastIndexOf(':') + 1), 10);
+        if (Number.isInteger(port)) ports.add(port);
+    }
+    return ports;
+};
+
+export const checkPortAvailable = async (port: number): Promise<{ free: boolean }> => {
+    const res = await probe(['ss', '-H', '-ltn']);
+    if (!res.ok) return { free: true }; // cannot determine; do not block
+    return { free: !parseListeningPorts(res.out).has(port) };
+};

--- a/src/deployment/ports.ts
+++ b/src/deployment/ports.ts
@@ -27,11 +27,14 @@ export const isPrivilegedPort = (p: number): boolean => p < 1024;
 export const parseListeningPorts = (ssOutput: string): Set<number> => {
     const ports = new Set<number>();
     for (const line of ssOutput.split('\n')) {
-        // local address is the 4th whitespace-separated column, e.g. 0.0.0.0:8080 or [::]:22
-        const local = line.trim().split(/\s+/)[3];
-        if (!local) continue;
-        const port = parseInt(local.slice(local.lastIndexOf(':') + 1), 10);
-        if (Number.isInteger(port)) ports.add(port);
+        for (const token of line.trim().split(/\s+/)) {
+            const colon = token.lastIndexOf(':');
+            if (colon === -1) continue;
+            const portStr = token.slice(colon + 1);
+            // Skip the peer column (ends in ':*') and any non-address token.
+            if (!/^\d+$/.test(portStr)) continue;
+            ports.add(parseInt(portStr, 10));
+        }
     }
     return ports;
 };

--- a/src/deployment/privileged.test.ts
+++ b/src/deployment/privileged.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { ensurePrivilegedBind } from './privileged';
+import type { Deployment } from './types';
+
+const dep = (over: Partial<Deployment>): Deployment => ({
+    kind: 'docker-standalone',
+    runtime: 'docker',
+    running: true,
+    imagePresent: true,
+    dockerAvailable: true,
+    dockerRunning: true,
+    hostPort: 8080,
+    internalPort: 8080,
+    ...over,
+});
+
+describe('ensurePrivilegedBind', () => {
+    it('is ok for a non-privileged port regardless of runtime', () => {
+        expect(ensurePrivilegedBind(dep({ runtime: 'podman' }), 8080)).toEqual({ kind: 'ok' });
+    });
+    it('is ok for rootful docker on a privileged port', () => {
+        expect(ensurePrivilegedBind(dep({ runtime: 'docker' }), 443)).toEqual({ kind: 'ok' });
+    });
+    it('asks for the sysctl on rootless podman privileged ports', () => {
+        const a = ensurePrivilegedBind(dep({ runtime: 'podman' }), 443);
+        expect(a.kind).toBe('manual');
+        if (a.kind === 'manual') expect(a.instructions).toContain('ip_unprivileged_port_start');
+    });
+    it('asks for setcap on native privileged ports', () => {
+        const a = ensurePrivilegedBind(dep({ kind: 'native-systemd', runtime: null }), 80);
+        expect(a.kind).toBe('manual');
+        if (a.kind === 'manual') expect(a.instructions).toContain('cap_net_bind_service');
+    });
+});

--- a/src/deployment/privileged.ts
+++ b/src/deployment/privileged.ts
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { deriveCapabilities } from './capabilities';
+import { isPrivilegedPort } from './ports';
+import type { Deployment } from './types';
+
+export type PrivilegedAction = { kind: 'ok' } | { kind: 'manual'; instructions: string };
+
+export const ensurePrivilegedBind = (d: Deployment, port: number): PrivilegedAction => {
+    if (!isPrivilegedPort(port)) return { kind: 'ok' };
+    switch (deriveCapabilities(d).privilegedPortStrategy) {
+        case 'docker-root':
+            return { kind: 'ok' };
+        case 'podman-sysctl':
+            return {
+                kind: 'manual',
+                instructions:
+                    `Rootless podman cannot bind port ${port}. On the host run: ` +
+                    `sysctl net.ipv4.ip_unprivileged_port_start=${port} (persist it in /etc/sysctl.d/), then retry.`,
+            };
+        case 'setcap':
+            return {
+                kind: 'manual',
+                instructions:
+                    `Binding port ${port} needs CAP_NET_BIND_SERVICE. Grant it with: ` +
+                    `setcap 'cap_net_bind_service=+ep' /path/to/birdnet-go, then retry.`,
+            };
+        default:
+            return {
+                kind: 'manual',
+                instructions: `Port ${port} is privileged and cannot be bound by this deployment.`,
+            };
+    }
+};

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -97,4 +97,16 @@ describe('recreateContainer', () => {
         const restoreCall = exec.mock.calls.find(c => Array.isArray(c[0]) && (c[0] as string[]).includes('8080:8080'));
         expect(restoreCall).toBeTruthy();
     });
+
+    it('surfaces the original error even if the restore run also fails', async () => {
+        exec.mockImplementation((argv: string[]) => {
+            if (argv[1] === 'inspect') return Promise.resolve(inspectJson);
+            if (argv.includes('443:8080')) return Promise.reject(new Error('port restricted')); // new run fails
+            if (argv.includes('8080:8080')) return Promise.reject(new Error('restore failed')); // restore also fails
+            return Promise.resolve(''); // stop, rm
+        });
+        await expect(recreateContainer('docker', 'abc', { hostPort: 443, internalPort: 8080 })).rejects.toThrow(
+            'port restricted'
+        );
+    });
 });

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const exec = vi.fn();
+vi.mock('./exec', () => ({ exec: (...a: unknown[]) => exec(...a) }));
+
+import { buildRunArgs, recreateContainer, type DockerInspect } from './recreate';
+
+afterEach(() => exec.mockReset());
+
+const inspect: DockerInspect = {
+    Name: '/birdnet-go',
+    Config: { Image: 'ghcr.io/tphakala/birdnet-go:nightly', Env: ['PATH=/usr/bin', 'TZ=UTC'] },
+    HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '8080' }], '8090/tcp': [{ HostPort: '8090' }] } },
+    Mounts: [{ Type: 'bind', Source: '/opt/birdnet-go/config', Destination: '/config' }],
+};
+
+describe('buildRunArgs', () => {
+    it('overrides only the internal-port mapping and preserves others, mounts, env, and image', () => {
+        const args = buildRunArgs('docker', inspect, { hostPort: 443, internalPort: 8080 });
+        expect(args).toEqual([
+            'docker',
+            'run',
+            '-d',
+            '--name',
+            'birdnet-go',
+            '--restart',
+            'unless-stopped',
+            '-p',
+            '443:8080',
+            '-p',
+            '8090:8090',
+            '-v',
+            '/opt/birdnet-go/config:/config',
+            '-e',
+            'TZ=UTC',
+            'ghcr.io/tphakala/birdnet-go:nightly',
+        ]);
+    });
+
+    it('keeps the current image when no image override is given and uses podman bin', () => {
+        const args = buildRunArgs('podman', inspect, { hostPort: 8081, internalPort: 8080 });
+        expect(args[0]).toBe('podman');
+        expect(args[args.length - 1]).toBe('ghcr.io/tphakala/birdnet-go:nightly');
+        expect(args).toContain('8081:8080');
+    });
+
+    it('applies an image override (for version switching)', () => {
+        const args = buildRunArgs('docker', inspect, {
+            hostPort: 8080,
+            internalPort: 8080,
+            image: 'ghcr.io/tphakala/birdnet-go:v1.2.3',
+        });
+        expect(args[args.length - 1]).toBe('ghcr.io/tphakala/birdnet-go:v1.2.3');
+    });
+
+    it('skips PATH and HOME env vars', () => {
+        const args = buildRunArgs(
+            'docker',
+            { ...inspect, Config: { Image: 'img', Env: ['PATH=/x', 'HOME=/root', 'KEEP=1'] } },
+            { hostPort: 8080, internalPort: 8080 }
+        );
+        expect(args).toContain('KEEP=1');
+        expect(args).not.toContain('PATH=/x');
+        expect(args).not.toContain('HOME=/root');
+    });
+
+    it('preserves a bound host interface so 127.0.0.1 is not widened to 0.0.0.0', () => {
+        const localhostBound: DockerInspect = {
+            Name: '/birdnet-go',
+            Config: { Image: 'img' },
+            HostConfig: { PortBindings: { '8080/tcp': [{ HostIp: '127.0.0.1', HostPort: '8080' }] } },
+        };
+        const args = buildRunArgs('docker', localhostBound, { hostPort: 443, internalPort: 8080 });
+        expect(args).toContain('127.0.0.1:443:8080');
+    });
+});
+
+describe('recreateContainer', () => {
+    const inspectJson = JSON.stringify([
+        {
+            Name: '/birdnet-go',
+            Config: { Image: 'img' },
+            HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '8080' }] } },
+        },
+    ]);
+
+    it('restores the original container when the new run fails', async () => {
+        exec.mockImplementation((argv: string[]) => {
+            if (argv[1] === 'inspect') return Promise.resolve(inspectJson);
+            if (argv.includes('443:8080')) return Promise.reject(new Error('port restricted')); // new run fails
+            return Promise.resolve(''); // stop, rm, restore run
+        });
+        await expect(recreateContainer('docker', 'abc', { hostPort: 443, internalPort: 8080 })).rejects.toThrow(
+            'port restricted'
+        );
+        // the restore run with the original 8080 mapping was issued
+        const restoreCall = exec.mock.calls.find(c => Array.isArray(c[0]) && (c[0] as string[]).includes('8080:8080'));
+        expect(restoreCall).toBeTruthy();
+    });
+});

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { exec } from './exec';
+
+export interface DockerInspect {
+    Name?: string;
+    Config?: { Image?: string; Env?: string[] };
+    HostConfig?: { PortBindings?: Record<string, { HostPort: string; HostIp?: string }[]> };
+    Mounts?: { Type: string; Source: string; Destination: string }[];
+}
+
+export interface RecreateOptions {
+    hostPort?: number;
+    internalPort?: number;
+    image?: string;
+}
+
+export const buildRunArgs = (bin: string, inspect: DockerInspect, opts: RecreateOptions): string[] => {
+    const name = (inspect.Name || '').replace('/', '');
+    const args = [bin, 'run', '-d', '--name', name, '--restart', 'unless-stopped'];
+    const internal = opts.internalPort ?? 8080;
+
+    const bindings = inspect.HostConfig?.PortBindings ?? {};
+    for (const [containerPort, hostPorts] of Object.entries(bindings)) {
+        const internalNum = containerPort.split('/')[0];
+        for (const b of hostPorts ?? []) {
+            const hostPort =
+                opts.hostPort != null && internalNum === String(internal) ? String(opts.hostPort) : b.HostPort;
+            // preserve a bound interface (e.g. 127.0.0.1) so a localhost-only
+            // binding is not silently widened to 0.0.0.0 on a port change
+            const ip = b.HostIp ? `${b.HostIp}:` : '';
+            args.push('-p', `${ip}${hostPort}:${internalNum}`);
+        }
+    }
+
+    for (const m of inspect.Mounts ?? []) {
+        if (m.Type === 'bind') args.push('-v', `${m.Source}:${m.Destination}`);
+    }
+
+    for (const env of inspect.Config?.Env ?? []) {
+        if (!env.startsWith('PATH=') && !env.startsWith('HOME=')) args.push('-e', env);
+    }
+
+    args.push(opts.image ?? inspect.Config?.Image ?? '');
+    return args;
+};
+
+export const recreateContainer = async (bin: string, containerId: string, opts: RecreateOptions): Promise<void> => {
+    const inspectJson = await exec([bin, 'inspect', containerId]);
+    const inspect = (JSON.parse(inspectJson) as DockerInspect[])[0];
+    if (!inspect) throw new Error('failed to inspect container');
+    await exec([bin, 'stop', containerId]);
+    await exec([bin, 'rm', containerId]);
+    try {
+        await exec(buildRunArgs(bin, inspect, opts));
+    } catch (err) {
+        // The new `docker run` failed after the old container was removed (e.g. a
+        // restricted port). Never leave the user with no container: recreate the
+        // original (original port mapping and image), then surface the failure.
+        const restoreOpts: RecreateOptions = {};
+        if (opts.internalPort !== undefined) restoreOpts.internalPort = opts.internalPort;
+        await exec(buildRunArgs(bin, inspect, restoreOpts));
+        throw err;
+    }
+};

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -76,7 +76,11 @@ export const recreateContainer = async (bin: string, containerId: string, opts: 
         // original (original port mapping and image), then surface the failure.
         const restoreOpts: RecreateOptions = {};
         if (opts.internalPort !== undefined) restoreOpts.internalPort = opts.internalPort;
-        await exec(buildRunArgs(bin, inspect, restoreOpts));
+        try {
+            await exec(buildRunArgs(bin, inspect, restoreOpts));
+        } catch {
+            // The restore run also failed; fall through and surface the original error.
+        }
         throw err;
     }
 };

--- a/src/deployment/safeApply.test.ts
+++ b/src/deployment/safeApply.test.ts
@@ -141,4 +141,14 @@ describe('safeSetPort', () => {
         const r = await safeSetPort(mkDriver(), standalone, 9000, 'h', deps);
         expect(r.kind).toBe('rolled-back');
     });
+
+    it('reports a guided-manual rollback when the restore cannot be applied automatically', async () => {
+        const guidedRollbackDriver = mkDriver({
+            setHostPort: vi.fn(async () => ({ kind: 'guided-manual' as const, instructions: 'edit the unit' })),
+        });
+        const deps = mkDeps({ pollHealth: vi.fn(async () => false), getDriver: vi.fn(() => guidedRollbackDriver) });
+        const r = await safeSetPort(mkDriver(), standalone, 9000, 'h', deps);
+        expect(r.kind).toBe('rolled-back');
+        if (r.kind === 'rolled-back') expect(r.reason).toContain('manual steps');
+    });
 });

--- a/src/deployment/safeApply.test.ts
+++ b/src/deployment/safeApply.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { safeSetPort, type SafeSetPortDeps } from './safeApply';
+import type { Deployment } from './types';
+import type { DeploymentDriver, PortChangeResult } from './driver';
+
+const standalone: Deployment = {
+    kind: 'docker-standalone',
+    runtime: 'docker',
+    running: true,
+    imagePresent: true,
+    dockerAvailable: true,
+    dockerRunning: true,
+    containerId: 'abc',
+    hostPort: 8080,
+    internalPort: 8080,
+};
+
+const mkDriver = (over: Partial<DeploymentDriver> = {}): DeploymentDriver => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    getHostPort: vi.fn(),
+    getCapabilities: () => ({ canChangePort: true, portChangeMode: 'auto', privilegedPortStrategy: 'docker-root' }),
+    setHostPort: vi.fn(async (): Promise<PortChangeResult> => ({ kind: 'applied' })),
+    ...over,
+});
+
+const mkDeps = (over: Partial<SafeSetPortDeps> = {}): SafeSetPortDeps => ({
+    checkPortAvailable: vi.fn(async () => ({ free: true })),
+    ensurePrivilegedBind: vi.fn(() => ({ kind: 'ok' as const })),
+    pollHealth: vi.fn(async () => true),
+    redetect: vi.fn(async () => standalone),
+    getDriver: vi.fn(() => mkDriver()),
+    ...over,
+});
+
+describe('safeSetPort', () => {
+    it('rejects an invalid port before doing anything', async () => {
+        const r = await safeSetPort(mkDriver(), standalone, 70000, 'h', mkDeps());
+        expect(r.kind).toBe('precheck-failed');
+    });
+
+    it('passes guided-manual deployments straight through', async () => {
+        const driver = mkDriver({
+            getCapabilities: () => ({
+                canChangePort: true,
+                portChangeMode: 'guided-manual',
+                privilegedPortStrategy: 'setcap',
+            }),
+            setHostPort: vi.fn(async () => ({ kind: 'guided-manual' as const, instructions: 'do X' })),
+        });
+        const r = await safeSetPort(driver, standalone, 443, 'h', mkDeps());
+        expect(r).toEqual({ kind: 'guided-manual', instructions: 'do X' });
+    });
+
+    it('fails precheck when the port is in use', async () => {
+        const r = await safeSetPort(
+            mkDriver(),
+            standalone,
+            443,
+            'h',
+            mkDeps({ checkPortAvailable: vi.fn(async () => ({ free: false })) })
+        );
+        expect(r.kind).toBe('precheck-failed');
+    });
+
+    it('fails precheck when a privileged bind needs manual host setup', async () => {
+        const r = await safeSetPort(
+            mkDriver(),
+            standalone,
+            80,
+            'h',
+            mkDeps({ ensurePrivilegedBind: vi.fn(() => ({ kind: 'manual' as const, instructions: 'sysctl ...' })) })
+        );
+        expect(r).toEqual({ kind: 'precheck-failed', reason: 'sysctl ...' });
+    });
+
+    it('applies and confirms health on the new port', async () => {
+        const setHostPort = vi.fn(async () => ({ kind: 'applied' as const }));
+        const r = await safeSetPort(mkDriver({ setHostPort }), standalone, 9000, 'h', mkDeps());
+        expect(setHostPort).toHaveBeenCalledWith(9000);
+        expect(r).toEqual({ kind: 'applied', hostPort: 9000 });
+    });
+
+    it('rolls back to the old port when health does not come up', async () => {
+        const rollbackDriver = mkDriver({ setHostPort: vi.fn(async () => ({ kind: 'applied' as const })) });
+        const deps = mkDeps({ pollHealth: vi.fn(async () => false), getDriver: vi.fn(() => rollbackDriver) });
+        const r = await safeSetPort(mkDriver(), standalone, 9000, 'h', deps);
+        expect(rollbackDriver.setHostPort).toHaveBeenCalledWith(8080); // back to snapshot
+        expect(r.kind).toBe('rolled-back');
+    });
+
+    it('reports rolled-back when applying the change throws', async () => {
+        const setHostPort = vi.fn(async () => {
+            throw new Error('docker run failed');
+        });
+        const r = await safeSetPort(mkDriver({ setHostPort }), standalone, 9000, 'h', mkDeps());
+        expect(r.kind).toBe('rolled-back');
+    });
+
+    it('allows re-applying the current port without an availability failure', async () => {
+        const checkPortAvailable = vi.fn(async () => ({ free: false }));
+        const r = await safeSetPort(mkDriver(), standalone, 8080, 'h', mkDeps({ checkPortAvailable }));
+        expect(checkPortAvailable).not.toHaveBeenCalled(); // same as current port, skip the check
+        expect(r.kind).toBe('applied');
+    });
+});

--- a/src/deployment/safeApply.test.ts
+++ b/src/deployment/safeApply.test.ts
@@ -105,4 +105,40 @@ describe('safeSetPort', () => {
         expect(checkPortAvailable).not.toHaveBeenCalled(); // same as current port, skip the check
         expect(r.kind).toBe('applied');
     });
+
+    it('fails precheck when the deployment cannot change its port', async () => {
+        const driver = mkDriver({
+            getCapabilities: () => ({
+                canChangePort: false,
+                portChangeMode: 'auto',
+                privilegedPortStrategy: 'docker-root',
+            }),
+        });
+        const r = await safeSetPort(driver, standalone, 9000, 'h', mkDeps());
+        expect(r.kind).toBe('precheck-failed');
+    });
+
+    it('passes through an applied result from a guided-manual driver', async () => {
+        const driver = mkDriver({
+            getCapabilities: () => ({
+                canChangePort: true,
+                portChangeMode: 'guided-manual',
+                privilegedPortStrategy: 'setcap',
+            }),
+            setHostPort: vi.fn(async () => ({ kind: 'applied' as const })),
+        });
+        const r = await safeSetPort(driver, standalone, 443, 'h', mkDeps());
+        expect(r).toEqual({ kind: 'applied', hostPort: 443 });
+    });
+
+    it('returns rolled-back (not a thrown error) when the rollback itself fails', async () => {
+        const failingRollbackDriver = mkDriver({
+            setHostPort: vi.fn(async () => {
+                throw new Error('rollback boom');
+            }),
+        });
+        const deps = mkDeps({ pollHealth: vi.fn(async () => false), getDriver: vi.fn(() => failingRollbackDriver) });
+        const r = await safeSetPort(mkDriver(), standalone, 9000, 'h', deps);
+        expect(r.kind).toBe('rolled-back');
+    });
 });

--- a/src/deployment/safeApply.ts
+++ b/src/deployment/safeApply.ts
@@ -105,7 +105,17 @@ export const safeSetPort = async (
     if (await deps.pollHealth(hostname, newPort)) return { kind: 'applied', hostPort: newPort };
 
     // applied but unhealthy: re-detect to get a driver bound to the new container, restore the old port
-    const after = await deps.redetect(hostname);
-    await deps.getDriver(after).setHostPort(snapshot);
-    return { kind: 'rolled-back', reason: `service did not become healthy on port ${newPort}; restored ${snapshot}` };
+    try {
+        const after = await deps.redetect(hostname);
+        await deps.getDriver(after).setHostPort(snapshot);
+        return {
+            kind: 'rolled-back',
+            reason: `service did not become healthy on port ${newPort}; restored ${snapshot}`,
+        };
+    } catch (e) {
+        return {
+            kind: 'rolled-back',
+            reason: `service did not become healthy on port ${newPort} and automatic rollback to ${snapshot} failed: ${(e as Error).message}`,
+        };
+    }
 };

--- a/src/deployment/safeApply.ts
+++ b/src/deployment/safeApply.ts
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import { getHealthUrl } from '../config';
+import { checkPortAvailable as realCheck, validatePort } from './ports';
+import { detectDeployment } from './detect';
+import { getDriver as realGetDriver } from './driver';
+import { ensurePrivilegedBind as realEnsure } from './privileged';
+import { exec } from './exec';
+import type { Deployment } from './types';
+import type { DeploymentDriver } from './driver';
+
+export type ApplyResult =
+    | { kind: 'applied'; hostPort: number }
+    | { kind: 'rolled-back'; reason: string }
+    | { kind: 'guided-manual'; instructions: string }
+    | { kind: 'precheck-failed'; reason: string };
+
+export interface SafeSetPortDeps {
+    checkPortAvailable: (port: number) => Promise<{ free: boolean }>;
+    ensurePrivilegedBind: (d: Deployment, port: number) => { kind: 'ok' } | { kind: 'manual'; instructions: string };
+    pollHealth: (hostname: string, port: number) => Promise<boolean>;
+    redetect: (hostname: string) => Promise<Deployment>;
+    getDriver: (d: Deployment) => DeploymentDriver;
+}
+
+/** Poll the health endpoint on a port until healthy or attempts run out. */
+export const pollHealth = async (hostname: string, port: number): Promise<boolean> => {
+    for (let i = 0; i < 10; i++) {
+        try {
+            const out = await exec(['curl', '-s', '-m', '3', getHealthUrl(hostname, port)]);
+            const status = (JSON.parse(out) as { status?: string }).status;
+            if (status === 'healthy' || status === 'degraded') return true;
+        } catch {
+            // not up yet
+        }
+        await new Promise(resolve => setTimeout(resolve, 1500));
+    }
+    return false;
+};
+
+export const defaultSafeSetPortDeps: SafeSetPortDeps = {
+    checkPortAvailable: realCheck,
+    ensurePrivilegedBind: realEnsure,
+    pollHealth,
+    redetect: detectDeployment,
+    getDriver: realGetDriver,
+};
+
+export const safeSetPort = async (
+    driver: DeploymentDriver,
+    deployment: Deployment,
+    newPort: number,
+    hostname: string,
+    deps: SafeSetPortDeps
+): Promise<ApplyResult> => {
+    if (!validatePort(newPort)) return { kind: 'precheck-failed', reason: `${newPort} is not a valid port` };
+
+    const caps = driver.getCapabilities();
+    if (!caps.canChangePort) return { kind: 'precheck-failed', reason: 'this deployment cannot change its port' };
+
+    if (caps.portChangeMode === 'guided-manual') {
+        const r = await driver.setHostPort(newPort);
+        return r.kind === 'guided-manual'
+            ? { kind: 'guided-manual', instructions: r.instructions }
+            : { kind: 'applied', hostPort: newPort };
+    }
+
+    // auto path
+    const priv = deps.ensurePrivilegedBind(deployment, newPort);
+    if (priv.kind === 'manual') return { kind: 'precheck-failed', reason: priv.instructions };
+
+    if (newPort !== deployment.hostPort) {
+        const avail = await deps.checkPortAvailable(newPort);
+        if (!avail.free) return { kind: 'precheck-failed', reason: `port ${newPort} is already in use` };
+    }
+
+    const snapshot = deployment.hostPort;
+    try {
+        await driver.setHostPort(newPort);
+    } catch (e) {
+        // recreateContainer restores the original container on a failed run, so the
+        // service is already back on its old port; just report the failure.
+        return {
+            kind: 'rolled-back',
+            reason: `failed to apply port ${newPort}: ${(e as Error).message}; restored ${snapshot}`,
+        };
+    }
+
+    if (await deps.pollHealth(hostname, newPort)) return { kind: 'applied', hostPort: newPort };
+
+    // applied but unhealthy: re-detect to get a driver bound to the new container, restore the old port
+    const after = await deps.redetect(hostname);
+    await deps.getDriver(after).setHostPort(snapshot);
+    return { kind: 'rolled-back', reason: `service did not become healthy on port ${newPort}; restored ${snapshot}` };
+};

--- a/src/deployment/safeApply.ts
+++ b/src/deployment/safeApply.ts
@@ -107,11 +107,12 @@ export const safeSetPort = async (
     // applied but unhealthy: re-detect to get a driver bound to the new container, restore the old port
     try {
         const after = await deps.redetect(hostname);
-        await deps.getDriver(after).setHostPort(snapshot);
-        return {
-            kind: 'rolled-back',
-            reason: `service did not become healthy on port ${newPort}; restored ${snapshot}`,
-        };
+        const restore = await deps.getDriver(after).setHostPort(snapshot);
+        const reason =
+            restore.kind === 'applied'
+                ? `service did not become healthy on port ${newPort}; restored ${snapshot}`
+                : `service did not become healthy on port ${newPort}; could not automatically restore port ${snapshot}, manual steps may be required: ${restore.instructions}`;
+        return { kind: 'rolled-back', reason };
     } catch (e) {
         return {
             kind: 'rolled-back',


### PR DESCRIPTION
## Summary

Builds on the M0 deployment-driver layer to let the user change the port BirdNET-Go listens on, including privileged ports (80/443), with a pre-flight availability check and an apply-verify-rollback safety net. The change is automatic for standalone Docker and shows exact guided instructions for the other deployment shapes.

A new "Network & Port" card shows the current port, a new-port input with a live availability badge, quick-set buttons for 80/443/8080 with inline privilege warnings, and an Apply button that drives the safe-apply flow with clear applied / rolled-back / precheck-failed / guided-manual states.

### What's in the layer

- `ports.ts` - port validation, privileged-port check, `ss`-based availability.
- `recreate.ts` - pure `buildRunArgs` plus `recreateContainer` (inspect, stop, rm, run), which restores the original container if the new run fails and re-throws the original error even when the restore also fails.
- `setHostPort` on the driver - auto-recreate for `docker-standalone`; guided-manual instructions for compose, docker-systemd, and native; a safe fallback for a standalone deployment with no container id.
- `privileged.ts` - advisory only: for a privileged port it either confirms the runtime can already bind it or returns the exact host change to make. M1 never mutates host capabilities automatically.
- `safeApply.ts` - `safeSetPort`: snapshot, pre-checks (validity, capability, privilege, availability with a same-port skip), apply, poll the health endpoint on the new port, and roll back to the old port if it does not come up. It always returns a typed result, even if the rollback itself throws.
- `components/PortCard.tsx` + app.tsx wiring.

### Scope (intentional, per the design)

Only `docker-standalone` applies automatically. Compose, docker-systemd, and native are guided-manual; automatic handling for those is a later milestone. Privileged-port needs that the runtime cannot satisfy are surfaced as instructions, never applied.

## Test Plan

- [x] `npm run format:check` clean
- [x] `npm run eslint` clean
- [x] `npm run typecheck` clean (strict + exactOptionalPropertyTypes)
- [x] `npx vitest run` green (191 tests, including the safety-net branches and the PortCard render tests)
- [x] `npm run build` succeeds
- [ ] CI: Lint & Build, CodeQL, Dependency Review

## Known limitation (follow-up, highest priority)

`recreateContainer` reproduces the container from `docker inspect` but only preserves the host port mappings, bind mounts, and environment. It does NOT re-apply `--device`, `--network`, the real restart policy, labels, or healthcheck. This matters for BirdNET-Go: installs that capture from a local sound card pass `--device /dev/snd`, and host-network setups pass `--network host`. A port change would recreate the container without those flags and could break audio capture or networking.

This is not a new regression: it is the same recreate behavior the existing container-upgrade path already uses, and the design scoped this milestone to reuse those semantics. It is worth a dedicated follow-up that benefits both the upgrade and the port-change paths: extend the inspect parsing and `buildRunArgs` to carry `HostConfig.RestartPolicy`, `Devices`, and `NetworkMode` (or warn before recreating a container that has flags the builder cannot reproduce).