### PR TITLE
Container-recreate config fidelity: reproduce device/network/restart flags, guard the rest

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,6 +50,7 @@ import {
 import type { ContainerStatus, DockerStatus, HealthStatus, LogEntry, SystemdStatus, VersionInfo } from './types';
 import { detectDeployment } from './deployment/detect';
 import { getDriver } from './deployment/driver';
+import { recreateContainer } from './deployment/recreate';
 import type { Deployment } from './deployment/types';
 import { PortCard } from './components/PortCard';
 import {
@@ -67,17 +68,6 @@ import {
 } from './utils';
 
 const _ = cockpit.gettext;
-
-interface DockerInspectResult {
-    Name: string;
-    HostConfig?: {
-        PortBindings?: Record<string, { HostPort: string }[]>;
-    };
-    Mounts?: { Type: string; Source: string; Destination: string }[];
-    Config?: {
-        Env?: string[];
-    };
-}
 
 export const Application = () => {
     const [deployment, setDeployment] = useState<Deployment>({
@@ -663,66 +653,17 @@ export const Application = () => {
                 // The service will pull and run the latest image
                 await cockpit.spawn(['systemctl', 'restart', SERVICE_NAME], { superuser: 'try' });
             } else if (containerStatus.containerId) {
-                // For standalone Docker container
-                // Stop current container
-                await cockpit.spawn(['docker', 'stop', containerStatus.containerId]);
-
-                // Get current container configuration
-                const configJson = await cockpit.spawn(['docker', 'inspect', containerStatus.containerId]);
-                const inspectResult = safeJsonParse<DockerInspectResult[]>(configJson, [], 'docker inspect output');
-                if (!inspectResult.length) {
-                    throw new Error('Failed to parse container configuration from docker inspect');
+                // Recreate the standalone container on the new image, reproducing its
+                // device/network/restart/mount flags. If the container carries settings
+                // that cannot be safely reproduced, leave it running and guide the user.
+                const result = await recreateContainer('docker', containerStatus.containerId, {
+                    image: imageName,
+                    internalPort: 8080,
+                });
+                if (result.kind === 'unsupported') {
+                    alert(`Could not upgrade automatically. ${result.instructions}`);
+                    return;
                 }
-                const config = inspectResult[0];
-
-                // Remove old container
-                await cockpit.spawn(['docker', 'rm', containerStatus.containerId]);
-
-                // Create new container with same configuration but new image
-                const createArgs = [
-                    'docker',
-                    'run',
-                    '-d',
-                    '--name',
-                    (config.Name || '').replace('/', ''),
-                    '--restart',
-                    'unless-stopped',
-                ];
-
-                // Preserve port mappings
-                if (config.HostConfig?.PortBindings) {
-                    Object.entries(config.HostConfig.PortBindings).forEach(([containerPort, hostPorts]) => {
-                        if (Array.isArray(hostPorts)) {
-                            hostPorts.forEach((binding: { HostPort: string }) => {
-                                createArgs.push('-p', `${binding.HostPort}:${containerPort.split('/')[0]}`);
-                            });
-                        }
-                    });
-                }
-
-                // Preserve volume mounts
-                if (config.Mounts) {
-                    config.Mounts.forEach((mount: { Type: string; Source: string; Destination: string }) => {
-                        if (mount.Type === 'bind') {
-                            createArgs.push('-v', `${mount.Source}:${mount.Destination}`);
-                        }
-                    });
-                }
-
-                // Preserve environment variables
-                if (config.Config?.Env) {
-                    config.Config.Env.forEach((env: string) => {
-                        // Skip PATH and other default envs
-                        if (!env.startsWith('PATH=') && !env.startsWith('HOME=')) {
-                            createArgs.push('-e', env);
-                        }
-                    });
-                }
-
-                createArgs.push(imageName);
-
-                // Create and start new container
-                await cockpit.spawn(createArgs);
             }
 
             // Refresh status after upgrade

--- a/src/deployment/dockerDriver.test.ts
+++ b/src/deployment/dockerDriver.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const exec = vi.fn().mockResolvedValue('');
 vi.mock('./exec', () => ({ exec: (...a: unknown[]) => exec(...a), probe: vi.fn() }));
 
-const recreate = vi.fn().mockResolvedValue(undefined);
+const recreate = vi.fn().mockResolvedValue({ kind: 'recreated' });
 vi.mock('./recreate', () => ({ recreateContainer: (...a: unknown[]) => recreate(...a) }));
 
 import { DockerDriver } from './dockerDriver';
@@ -72,6 +72,16 @@ describe('DockerDriver.setHostPort', () => {
         const r = await new DockerDriver(compose).setHostPort(443);
         expect(r.kind).toBe('guided-manual');
         if (r.kind === 'guided-manual') expect(r.instructions).toContain('/srv/bng');
+    });
+
+    it('returns guided-manual when the container cannot be reproduced', async () => {
+        recreate.mockResolvedValueOnce({
+            kind: 'unsupported',
+            reasons: ['privileged mode (--privileged)'],
+            instructions: 'recreate by hand',
+        });
+        const r = await new DockerDriver(standalone).setHostPort(443);
+        expect(r).toEqual({ kind: 'guided-manual', instructions: 'recreate by hand' });
     });
 
     it('returns guided-manual instructions for a standalone deployment missing its container id', async () => {

--- a/src/deployment/dockerDriver.ts
+++ b/src/deployment/dockerDriver.ts
@@ -64,10 +64,13 @@ export class DockerDriver implements DeploymentDriver {
 
     async setHostPort(port: number): Promise<PortChangeResult> {
         if (this.d.kind === 'docker-standalone' && this.d.containerId) {
-            await recreateContainer(this.bin(), this.d.containerId, {
+            const result = await recreateContainer(this.bin(), this.d.containerId, {
                 hostPort: port,
                 internalPort: this.d.internalPort,
             });
+            if (result.kind === 'unsupported') {
+                return { kind: 'guided-manual', instructions: result.instructions };
+            }
             return { kind: 'applied' };
         }
         if (this.d.kind === 'docker-compose') {

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -197,6 +197,39 @@ describe('recreateContainer', () => {
             'port restricted'
         );
     });
+
+    it('returns unsupported and never stops or removes a container it cannot reproduce', async () => {
+        const namedVolJson = JSON.stringify([
+            {
+                Name: '/birdnet-go',
+                Config: { Image: 'img' },
+                HostConfig: { PortBindings: { '8080/tcp': [{ HostPort: '8080' }] } },
+                Mounts: [{ Type: 'volume', Source: 'bng-data', Destination: '/data' }],
+            },
+        ]);
+        exec.mockImplementation((argv: string[]) => {
+            if (argv[1] === 'inspect') return Promise.resolve(namedVolJson);
+            return Promise.resolve('');
+        });
+        const result = await recreateContainer('docker', 'abc', { hostPort: 443, internalPort: 8080 });
+        expect(result.kind).toBe('unsupported');
+        // the container must be left untouched
+        const touched = exec.mock.calls.some(
+            c => Array.isArray(c[0]) && ((c[0] as string[])[1] === 'stop' || (c[0] as string[])[1] === 'rm')
+        );
+        expect(touched).toBe(false);
+    });
+
+    it('returns recreated and issues stop/rm/run for a reproducible container', async () => {
+        exec.mockImplementation((argv: string[]) => {
+            if (argv[1] === 'inspect') return Promise.resolve(inspectJson);
+            return Promise.resolve('');
+        });
+        const result = await recreateContainer('docker', 'abc', { hostPort: 8081, internalPort: 8080 });
+        expect(result).toEqual({ kind: 'recreated' });
+        expect(exec.mock.calls.some(c => (c[0] as string[])[1] === 'stop')).toBe(true);
+        expect(exec.mock.calls.some(c => (c[0] as string[])[1] === 'rm')).toBe(true);
+    });
 });
 
 describe('findUnreproducible', () => {

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const exec = vi.fn();
 vi.mock('./exec', () => ({ exec: (...a: unknown[]) => exec(...a) }));
 
-import { buildRunArgs, recreateContainer, type DockerInspect } from './recreate';
+import {
+    buildManualInstructions,
+    buildRunArgs,
+    findUnreproducible,
+    recreateContainer,
+    type DockerInspect,
+} from './recreate';
 
 afterEach(() => exec.mockReset());
 
@@ -190,5 +196,84 @@ describe('recreateContainer', () => {
         await expect(recreateContainer('docker', 'abc', { hostPort: 443, internalPort: 8080 })).rejects.toThrow(
             'port restricted'
         );
+    });
+});
+
+describe('findUnreproducible', () => {
+    const clean: DockerInspect = {
+        Name: '/birdnet-go',
+        Config: { Image: 'img' },
+        HostConfig: {
+            PortBindings: { '8080/tcp': [{ HostPort: '8080' }] },
+            Devices: [{ PathOnHost: '/dev/snd', PathInContainer: '/dev/snd', CgroupPermissions: 'rwm' }],
+            NetworkMode: 'bridge',
+            RestartPolicy: { Name: 'unless-stopped' },
+        },
+        Mounts: [{ Type: 'bind', Source: '/cfg', Destination: '/config' }],
+    };
+
+    it('returns no reasons for a reproducible sound-card container', () => {
+        expect(findUnreproducible(clean, { hostPort: 80, internalPort: 8080 })).toEqual([]);
+    });
+
+    it.each([
+        ['named volume', { Mounts: [{ Type: 'volume', Source: 'vol', Destination: '/data' }] }],
+        ['privileged', { HostConfig: { Privileged: true } }],
+        ['cap-add', { HostConfig: { CapAdd: ['NET_ADMIN'] } }],
+        ['cap-drop', { HostConfig: { CapDrop: ['ALL'] } }],
+        ['tmpfs', { HostConfig: { Tmpfs: { '/run': '' } } }],
+        ['sysctls', { HostConfig: { Sysctls: { 'net.core.somaxconn': '1024' } } }],
+        ['ulimits', { HostConfig: { Ulimits: [{}] } }],
+        ['group-add', { HostConfig: { GroupAdd: ['audio'] } }],
+        ['extra-hosts', { HostConfig: { ExtraHosts: ['db:1.2.3.4'] } }],
+        ['dns', { HostConfig: { Dns: ['1.1.1.1'] } }],
+        ['security-opt', { HostConfig: { SecurityOpt: ['label=disable'] } }],
+        ['device-cgroup-rules', { HostConfig: { DeviceCgroupRules: ['c 1:3 rwm'] } }],
+        ['device-requests (gpu)', { HostConfig: { DeviceRequests: [{}] } }],
+        ['custom runtime', { HostConfig: { Runtime: 'nvidia' } }],
+        ['custom user', { Config: { Image: 'img', User: '1000:1000' } }],
+        ['compose labels', { Config: { Image: 'img', Labels: { 'com.docker.compose.project': 'p' } } }],
+    ])('flags %s', (_label, partial) => {
+        const i: DockerInspect = { Name: '/x', Config: { Image: 'img' }, ...partial } as DockerInspect;
+        expect(findUnreproducible(i, {}).length).toBeGreaterThan(0);
+    });
+
+    it('flags a static IP or aliases on a custom network', () => {
+        const i: DockerInspect = {
+            Name: '/x',
+            Config: { Image: 'img' },
+            HostConfig: { NetworkMode: 'mynet' },
+            NetworkSettings: { Networks: { mynet: { IPAMConfig: { IPv4Address: '10.0.0.5' }, Aliases: ['bng'] } } },
+        };
+        expect(findUnreproducible(i, {}).length).toBeGreaterThan(0);
+    });
+
+    it('does not flag a plain custom network with no static IP or aliases', () => {
+        const i: DockerInspect = {
+            Name: '/x',
+            Config: { Image: 'img' },
+            HostConfig: { NetworkMode: 'mynet' },
+            NetworkSettings: { Networks: { mynet: { IPAMConfig: null, Aliases: null } } },
+        };
+        expect(findUnreproducible(i, {})).toEqual([]);
+    });
+
+    it('flags a port change on a host-network container but not an upgrade', () => {
+        const i: DockerInspect = { Name: '/x', Config: { Image: 'img' }, HostConfig: { NetworkMode: 'host' } };
+        expect(findUnreproducible(i, { hostPort: 80 }).length).toBeGreaterThan(0);
+        expect(findUnreproducible(i, { image: 'img:v2' })).toEqual([]);
+    });
+});
+
+describe('buildManualInstructions', () => {
+    it('mentions the reasons and the port change', () => {
+        const msg = buildManualInstructions(['privileged mode (--privileged)'], { hostPort: 443 });
+        expect(msg).toContain('privileged mode (--privileged)');
+        expect(msg).toContain('443');
+    });
+
+    it('describes an upgrade when no host port is given', () => {
+        const msg = buildManualInstructions(['a named volume (vol) at /data'], { image: 'img:v2' });
+        expect(msg.toLowerCase()).toContain('upgrade');
     });
 });

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -268,6 +268,8 @@ describe('findUnreproducible', () => {
         ['group-add', { HostConfig: { GroupAdd: ['audio'] } }],
         ['extra-hosts', { HostConfig: { ExtraHosts: ['db:1.2.3.4'] } }],
         ['dns', { HostConfig: { Dns: ['1.1.1.1'] } }],
+        ['dns-search', { HostConfig: { DnsSearch: ['example.com'] } }],
+        ['dns-options', { HostConfig: { DnsOptions: ['ndots:2'] } }],
         ['security-opt', { HostConfig: { SecurityOpt: ['label=disable'] } }],
         ['device-cgroup-rules', { HostConfig: { DeviceCgroupRules: ['c 1:3 rwm'] } }],
         ['device-requests (gpu)', { HostConfig: { DeviceRequests: [{}] } }],

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -75,6 +75,88 @@ describe('buildRunArgs', () => {
     });
 });
 
+describe('buildRunArgs reproduction', () => {
+    it('reproduces --device for a sound card in simple form', () => {
+        const i: DockerInspect = {
+            Name: '/birdnet-go',
+            Config: { Image: 'img' },
+            HostConfig: {
+                PortBindings: { '8080/tcp': [{ HostPort: '8080' }] },
+                Devices: [{ PathOnHost: '/dev/snd', PathInContainer: '/dev/snd', CgroupPermissions: 'rwm' }],
+            },
+        };
+        const args = buildRunArgs('docker', i, { hostPort: 80, internalPort: 8080 });
+        expect(args[args.indexOf('--device') + 1]).toBe('/dev/snd');
+    });
+
+    it('uses the explicit --device form when paths or perms differ', () => {
+        const i: DockerInspect = {
+            Name: '/birdnet-go',
+            Config: { Image: 'img' },
+            HostConfig: {
+                Devices: [{ PathOnHost: '/dev/snd', PathInContainer: '/dev/audio', CgroupPermissions: 'rw' }],
+            },
+        };
+        const args = buildRunArgs('docker', i, {});
+        expect(args[args.indexOf('--device') + 1]).toBe('/dev/snd:/dev/audio:rw');
+    });
+
+    it('reproduces --network host and omits -p under host networking', () => {
+        const i: DockerInspect = {
+            Name: '/birdnet-go',
+            Config: { Image: 'img' },
+            HostConfig: { NetworkMode: 'host', PortBindings: { '8080/tcp': [{ HostPort: '8080' }] } },
+        };
+        const args = buildRunArgs('docker', i, { hostPort: 80, internalPort: 8080 });
+        expect(args[args.indexOf('--network') + 1]).toBe('host');
+        expect(args).not.toContain('-p');
+    });
+
+    it('does not emit --network for default or bridge', () => {
+        const i: DockerInspect = { Name: '/x', Config: { Image: 'img' }, HostConfig: { NetworkMode: 'bridge' } };
+        expect(buildRunArgs('docker', i, {})).not.toContain('--network');
+    });
+
+    it('preserves the real restart policy including on-failure count', () => {
+        const i: DockerInspect = {
+            Name: '/x',
+            Config: { Image: 'img' },
+            HostConfig: { RestartPolicy: { Name: 'on-failure', MaximumRetryCount: 5 } },
+        };
+        const args = buildRunArgs('docker', i, {});
+        expect(args[args.indexOf('--restart') + 1]).toBe('on-failure:5');
+    });
+
+    it('defaults restart policy to unless-stopped when inspect carries none', () => {
+        const i: DockerInspect = { Name: '/x', Config: { Image: 'img' }, HostConfig: {} };
+        const args = buildRunArgs('docker', i, {});
+        expect(args[args.indexOf('--restart') + 1]).toBe('unless-stopped');
+    });
+
+    it('omits --restart for an explicit "no" policy (docker default)', () => {
+        const i: DockerInspect = {
+            Name: '/x',
+            Config: { Image: 'img' },
+            HostConfig: { RestartPolicy: { Name: 'no' } },
+        };
+        expect(buildRunArgs('docker', i, {})).not.toContain('--restart');
+    });
+
+    it('adds :ro and propagation suffixes on bind mounts', () => {
+        const i: DockerInspect = {
+            Name: '/x',
+            Config: { Image: 'img' },
+            Mounts: [
+                { Type: 'bind', Source: '/data', Destination: '/data', RW: false },
+                { Type: 'bind', Source: '/ext', Destination: '/ext', Propagation: 'rshared' },
+            ],
+        };
+        const args = buildRunArgs('docker', i, {});
+        expect(args).toContain('/data:/data:ro');
+        expect(args).toContain('/ext:/ext:rshared');
+    });
+});
+
 describe('recreateContainer', () => {
     const inspectJson = JSON.stringify([
         {

--- a/src/deployment/recreate.test.ts
+++ b/src/deployment/recreate.test.ts
@@ -210,6 +210,14 @@ describe('findUnreproducible', () => {
             RestartPolicy: { Name: 'unless-stopped' },
         },
         Mounts: [{ Type: 'bind', Source: '/cfg', Destination: '/config' }],
+        NetworkSettings: {
+            Networks: {
+                bridge: {
+                    IPAMConfig: { IPv4Address: '172.17.0.3' },
+                    Aliases: ['birdnet-go'],
+                },
+            },
+        },
     };
 
     it('returns no reasons for a reproducible sound-card container', () => {

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -41,6 +41,8 @@ export interface DockerInspect {
         GroupAdd?: string[] | null;
         ExtraHosts?: string[] | null;
         Dns?: string[] | null;
+        DnsSearch?: string[] | null;
+        DnsOptions?: string[] | null;
         SecurityOpt?: string[] | null;
         DeviceCgroupRules?: string[] | null;
         DeviceRequests?: unknown[] | null;
@@ -71,6 +73,9 @@ export const buildRunArgs = (bin: string, inspect: DockerInspect, opts: Recreate
     const name = (inspect.Name || '').replace('/', '');
     const args = [bin, 'run', '-d', '--name', name];
 
+    // Absent or empty policy name defaults to unless-stopped (preserves prior behavior;
+    // the installer always sets unless-stopped). An explicit 'no' emits nothing, which is
+    // docker's own default. The two "no restart" encodings are intentionally distinct.
     // Restart policy: preserve the real value. Default to unless-stopped only when
     // inspect carries no policy (keeps prior behavior and never drops restart by omission).
     const policy = inspect.HostConfig?.RestartPolicy;
@@ -156,11 +161,20 @@ export const findUnreproducible = (inspect: DockerInspect, opts: RecreateOptions
     if (hc.GroupAdd?.length) reasons.push('supplementary groups (--group-add)');
     if (hc.ExtraHosts?.length) reasons.push('extra hosts (--add-host)');
     if (hc.Dns?.length) reasons.push('custom DNS servers (--dns)');
+    if (hc.DnsSearch?.length) reasons.push('custom DNS search domains (--dns-search)');
+    if (hc.DnsOptions?.length) reasons.push('custom DNS options (--dns-option)');
     if (hc.SecurityOpt?.length) reasons.push('security options (--security-opt)');
     if (hc.DeviceCgroupRules?.length) reasons.push('device cgroup rules');
     if (hc.DeviceRequests?.length) reasons.push('device requests such as GPUs (--gpus)');
+    // Note for the future podman migration: podman's default runtime is crun/oci, not
+    // runc, so this check will need a runtime allowlist before podman containers reach it.
     if (hc.Runtime && hc.Runtime !== 'runc') reasons.push(`a custom runtime (${hc.Runtime})`);
 
+    // Config.User reflects a runtime --user OR an image-baked USER directive (inspect
+    // cannot tell them apart). Safe today because the BirdNET-Go image runs as root and
+    // drops privileges via BIRDNET_UID/GID env, so this is empty for a normal install.
+    // If the image ever bakes a USER, this would over-trigger guided-manual (safe, not a
+    // silent drop).
     const user = inspect.Config?.User;
     if (user && user !== '') reasons.push(`a custom user (--user ${user})`);
 

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -64,6 +64,9 @@ export interface RecreateOptions {
 // NetworkMode values that mean "the default bridge network" and so need no --network flag.
 const DEFAULT_NETWORK_MODES = new Set(['', 'default', 'bridge']);
 
+// Network names that are docker built-ins (reproducible via --network or the default).
+const BUILTIN_NETWORK_NAMES = new Set(['bridge', 'host', 'none', 'default']);
+
 export const buildRunArgs = (bin: string, inspect: DockerInspect, opts: RecreateOptions): string[] => {
     const name = (inspect.Name || '').replace('/', '');
     const args = [bin, 'run', '-d', '--name', name];
@@ -129,6 +132,70 @@ export const buildRunArgs = (bin: string, inspect: DockerInspect, opts: Recreate
 
     args.push(opts.image ?? inspect.Config?.Image ?? '');
     return args;
+};
+
+/**
+ * Curated list of container settings buildRunArgs cannot faithfully reproduce.
+ * A non-empty result means the container must NOT be auto-recreated; the caller
+ * should fall back to guided-manual steps so nothing is silently dropped. This is
+ * a known-impactful field set, not an exhaustive inspect diff.
+ */
+export const findUnreproducible = (inspect: DockerInspect, opts: RecreateOptions): string[] => {
+    const reasons: string[] = [];
+    const hc = inspect.HostConfig ?? {};
+
+    for (const m of inspect.Mounts ?? []) {
+        if (m.Type !== 'bind') reasons.push(`a non-bind mount (${m.Type}) at ${m.Destination}`);
+    }
+    if (hc.Privileged) reasons.push('privileged mode (--privileged)');
+    if (hc.CapAdd?.length) reasons.push(`added capabilities (${hc.CapAdd.join(', ')})`);
+    if (hc.CapDrop?.length) reasons.push(`dropped capabilities (${hc.CapDrop.join(', ')})`);
+    if (hc.Tmpfs && Object.keys(hc.Tmpfs).length) reasons.push('tmpfs mounts (--tmpfs)');
+    if (hc.Sysctls && Object.keys(hc.Sysctls).length) reasons.push('custom sysctls (--sysctl)');
+    if (hc.Ulimits?.length) reasons.push('custom ulimits (--ulimit)');
+    if (hc.GroupAdd?.length) reasons.push('supplementary groups (--group-add)');
+    if (hc.ExtraHosts?.length) reasons.push('extra hosts (--add-host)');
+    if (hc.Dns?.length) reasons.push('custom DNS servers (--dns)');
+    if (hc.SecurityOpt?.length) reasons.push('security options (--security-opt)');
+    if (hc.DeviceCgroupRules?.length) reasons.push('device cgroup rules');
+    if (hc.DeviceRequests?.length) reasons.push('device requests such as GPUs (--gpus)');
+    if (hc.Runtime && hc.Runtime !== '' && hc.Runtime !== 'runc') reasons.push(`a custom runtime (${hc.Runtime})`);
+
+    const user = inspect.Config?.User;
+    if (user && user !== '') reasons.push(`a custom user (--user ${user})`);
+
+    const labels = inspect.Config?.Labels ?? {};
+    if (Object.keys(labels).some(k => k.startsWith('com.docker.compose.'))) {
+        reasons.push('Docker Compose management (compose labels)');
+    }
+
+    const networks = inspect.NetworkSettings?.Networks ?? {};
+    const netNames = Object.keys(networks);
+    if (netNames.length > 1) reasons.push('attachment to more than one network');
+    for (const [netName, ep] of Object.entries(networks)) {
+        if (BUILTIN_NETWORK_NAMES.has(netName)) continue;
+        const ipam = ep?.IPAMConfig;
+        if (ipam && (ipam.IPv4Address || ipam.IPv6Address)) reasons.push('a static IP address on a custom network');
+        if (ep?.Aliases?.length) reasons.push('network aliases on a custom network');
+    }
+
+    // A host port change is meaningless under host networking: the listen port lives
+    // in BirdNET-Go's config, not in a host port mapping.
+    if (opts.hostPort != null && inspect.HostConfig?.NetworkMode === 'host') {
+        reasons.push('host networking, where the listen port is set in BirdNET-Go config, not a host port mapping');
+    }
+
+    return reasons;
+};
+
+/** Build a short guided-manual message from the reasons a container is not reproducible. */
+export const buildManualInstructions = (reasons: string[], opts: RecreateOptions): string => {
+    const action = opts.hostPort != null ? `change the port to ${opts.hostPort}` : 'upgrade';
+    return (
+        `This container uses settings this tool cannot safely reproduce automatically: ${reasons.join('; ')}. ` +
+        `To avoid losing them, ${action} by hand: stop and remove the container, then re-run "docker run" ` +
+        `with all of its current flags plus your change.`
+    );
 };
 
 export const recreateContainer = async (bin: string, containerId: string, opts: RecreateOptions): Promise<void> => {

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -21,9 +21,38 @@ import { exec } from './exec';
 
 export interface DockerInspect {
     Name?: string;
-    Config?: { Image?: string; Env?: string[] };
-    HostConfig?: { PortBindings?: Record<string, { HostPort: string; HostIp?: string }[]> };
-    Mounts?: { Type: string; Source: string; Destination: string }[];
+    Config?: {
+        Image?: string;
+        Env?: string[];
+        Labels?: Record<string, string> | null;
+        User?: string;
+    };
+    HostConfig?: {
+        PortBindings?: Record<string, { HostPort: string; HostIp?: string }[]>;
+        Devices?: { PathOnHost: string; PathInContainer: string; CgroupPermissions?: string }[] | null;
+        NetworkMode?: string;
+        RestartPolicy?: { Name?: string; MaximumRetryCount?: number };
+        CapAdd?: string[] | null;
+        CapDrop?: string[] | null;
+        Privileged?: boolean;
+        Tmpfs?: Record<string, string> | null;
+        Sysctls?: Record<string, string> | null;
+        Ulimits?: unknown[] | null;
+        GroupAdd?: string[] | null;
+        ExtraHosts?: string[] | null;
+        Dns?: string[] | null;
+        SecurityOpt?: string[] | null;
+        DeviceCgroupRules?: string[] | null;
+        DeviceRequests?: unknown[] | null;
+        Runtime?: string;
+    };
+    Mounts?: { Type: string; Source: string; Destination: string; RW?: boolean; Propagation?: string }[];
+    NetworkSettings?: {
+        Networks?: Record<
+            string,
+            { IPAMConfig?: { IPv4Address?: string; IPv6Address?: string } | null; Aliases?: string[] | null }
+        > | null;
+    };
 }
 
 export interface RecreateOptions {
@@ -32,26 +61,66 @@ export interface RecreateOptions {
     image?: string;
 }
 
+// NetworkMode values that mean "the default bridge network" and so need no --network flag.
+const DEFAULT_NETWORK_MODES = new Set(['', 'default', 'bridge']);
+
 export const buildRunArgs = (bin: string, inspect: DockerInspect, opts: RecreateOptions): string[] => {
     const name = (inspect.Name || '').replace('/', '');
-    const args = [bin, 'run', '-d', '--name', name, '--restart', 'unless-stopped'];
+    const args = [bin, 'run', '-d', '--name', name];
+
+    // Restart policy: preserve the real value. Default to unless-stopped only when
+    // inspect carries no policy (keeps prior behavior and never drops restart by omission).
+    const policy = inspect.HostConfig?.RestartPolicy;
+    const policyName = policy?.Name ? policy.Name : undefined;
+    if (policyName === undefined) {
+        args.push('--restart', 'unless-stopped');
+    } else if (policyName !== 'no') {
+        const count = policyName === 'on-failure' && policy?.MaximumRetryCount ? `:${policy.MaximumRetryCount}` : '';
+        args.push('--restart', `${policyName}${count}`);
+    }
+    // policyName === 'no' is docker's default; emit nothing.
+
+    // Network mode: reproduce any non-default mode (host, none, a named network).
+    const netMode = inspect.HostConfig?.NetworkMode ?? '';
+    const hostNet = netMode === 'host';
+    if (!DEFAULT_NETWORK_MODES.has(netMode)) args.push('--network', netMode);
+
     const internal = opts.internalPort ?? 8080;
 
-    const bindings = inspect.HostConfig?.PortBindings ?? {};
-    for (const [containerPort, hostPorts] of Object.entries(bindings)) {
-        const internalNum = containerPort.split('/')[0];
-        for (const b of hostPorts ?? []) {
-            const hostPort =
-                opts.hostPort != null && internalNum === String(internal) ? String(opts.hostPort) : b.HostPort;
-            // preserve a bound interface (e.g. 127.0.0.1) so a localhost-only
-            // binding is not silently widened to 0.0.0.0 on a port change
-            const ip = b.HostIp ? `${b.HostIp}:` : '';
-            args.push('-p', `${ip}${hostPort}:${internalNum}`);
+    // Port bindings. Host networking ignores -p, so skip the mappings entirely there.
+    if (!hostNet) {
+        const bindings = inspect.HostConfig?.PortBindings ?? {};
+        for (const [containerPort, hostPorts] of Object.entries(bindings)) {
+            const internalNum = containerPort.split('/')[0];
+            for (const b of hostPorts ?? []) {
+                const hostPort =
+                    opts.hostPort != null && internalNum === String(internal) ? String(opts.hostPort) : b.HostPort;
+                // preserve a bound interface (e.g. 127.0.0.1) so a localhost-only
+                // binding is not silently widened to 0.0.0.0 on a port change
+                const ip = b.HostIp ? `${b.HostIp}:` : '';
+                args.push('-p', `${ip}${hostPort}:${internalNum}`);
+            }
         }
     }
 
+    // Devices (e.g. --device /dev/snd for sound-card capture).
+    for (const dev of inspect.HostConfig?.Devices ?? []) {
+        const perms = dev.CgroupPermissions ?? 'rwm';
+        if (dev.PathOnHost === dev.PathInContainer && perms === 'rwm') {
+            args.push('--device', dev.PathOnHost);
+        } else {
+            args.push('--device', `${dev.PathOnHost}:${dev.PathInContainer}:${perms}`);
+        }
+    }
+
+    // Bind mounts, preserving read-only and a non-default propagation mode.
     for (const m of inspect.Mounts ?? []) {
-        if (m.Type === 'bind') args.push('-v', `${m.Source}:${m.Destination}`);
+        if (m.Type !== 'bind') continue;
+        const suffix: string[] = [];
+        if (m.RW === false) suffix.push('ro');
+        if (m.Propagation && m.Propagation !== 'rprivate') suffix.push(m.Propagation);
+        const opt = suffix.length ? `:${suffix.join(',')}` : '';
+        args.push('-v', `${m.Source}:${m.Destination}${opt}`);
     }
 
     for (const env of inspect.Config?.Env ?? []) {

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -198,10 +198,23 @@ export const buildManualInstructions = (reasons: string[], opts: RecreateOptions
     );
 };
 
-export const recreateContainer = async (bin: string, containerId: string, opts: RecreateOptions): Promise<void> => {
+export type RecreateResult = { kind: 'recreated' } | { kind: 'unsupported'; reasons: string[]; instructions: string };
+
+export const recreateContainer = async (
+    bin: string,
+    containerId: string,
+    opts: RecreateOptions
+): Promise<RecreateResult> => {
     const inspectJson = await exec([bin, 'inspect', containerId]);
     const inspect = (JSON.parse(inspectJson) as DockerInspect[])[0];
     if (!inspect) throw new Error('failed to inspect container');
+
+    const reasons = findUnreproducible(inspect, opts);
+    if (reasons.length) {
+        // Leave the container running and untouched; the caller surfaces manual steps.
+        return { kind: 'unsupported', reasons, instructions: buildManualInstructions(reasons, opts) };
+    }
+
     await exec([bin, 'stop', containerId]);
     await exec([bin, 'rm', containerId]);
     try {
@@ -219,4 +232,5 @@ export const recreateContainer = async (bin: string, containerId: string, opts: 
         }
         throw err;
     }
+    return { kind: 'recreated' };
 };

--- a/src/deployment/recreate.ts
+++ b/src/deployment/recreate.ts
@@ -159,7 +159,7 @@ export const findUnreproducible = (inspect: DockerInspect, opts: RecreateOptions
     if (hc.SecurityOpt?.length) reasons.push('security options (--security-opt)');
     if (hc.DeviceCgroupRules?.length) reasons.push('device cgroup rules');
     if (hc.DeviceRequests?.length) reasons.push('device requests such as GPUs (--gpus)');
-    if (hc.Runtime && hc.Runtime !== '' && hc.Runtime !== 'runc') reasons.push(`a custom runtime (${hc.Runtime})`);
+    if (hc.Runtime && hc.Runtime !== 'runc') reasons.push(`a custom runtime (${hc.Runtime})`);
 
     const user = inspect.Config?.User;
     if (user && user !== '') reasons.push(`a custom user (--user ${user})`);

--- a/src/deployment/safeApply.test.ts
+++ b/src/deployment/safeApply.test.ts
@@ -151,4 +151,14 @@ describe('safeSetPort', () => {
         expect(r.kind).toBe('rolled-back');
         if (r.kind === 'rolled-back') expect(r.reason).toContain('manual steps');
     });
+
+    it('returns guided-manual without polling health when an auto driver cannot reproduce the container', async () => {
+        const pollHealth = vi.fn(async () => true);
+        const driver = mkDriver({
+            setHostPort: vi.fn(async () => ({ kind: 'guided-manual' as const, instructions: 'recreate by hand' })),
+        });
+        const r = await safeSetPort(driver, standalone, 443, 'h', mkDeps({ pollHealth }));
+        expect(r).toEqual({ kind: 'guided-manual', instructions: 'recreate by hand' });
+        expect(pollHealth).not.toHaveBeenCalled();
+    });
 });

--- a/src/deployment/safeApply.ts
+++ b/src/deployment/safeApply.ts
@@ -23,7 +23,7 @@ import { getDriver as realGetDriver } from './driver';
 import { ensurePrivilegedBind as realEnsure } from './privileged';
 import { exec } from './exec';
 import type { Deployment } from './types';
-import type { DeploymentDriver } from './driver';
+import type { DeploymentDriver, PortChangeResult } from './driver';
 
 export type ApplyResult =
     | { kind: 'applied'; hostPort: number }
@@ -91,8 +91,9 @@ export const safeSetPort = async (
     }
 
     const snapshot = deployment.hostPort;
+    let applied: PortChangeResult;
     try {
-        await driver.setHostPort(newPort);
+        applied = await driver.setHostPort(newPort);
     } catch (e) {
         // recreateContainer restores the original container on a failed run, so the
         // service is already back on its old port; just report the failure.
@@ -100,6 +101,11 @@ export const safeSetPort = async (
             kind: 'rolled-back',
             reason: `failed to apply port ${newPort}: ${(e as Error).message}; restored ${snapshot}`,
         };
+    }
+
+    // The driver could not safely recreate the container; nothing was changed.
+    if (applied.kind === 'guided-manual') {
+        return { kind: 'guided-manual', instructions: applied.instructions };
     }
 
     if (await deps.pollHealth(hostname, newPort)) return { kind: 'applied', hostPort: newPort };


### PR DESCRIPTION
## Summary

When the plugin recreates a BirdNET-Go container (to change its host port, or to swap the image on upgrade), the recreate builder previously preserved only host port mappings, bind mounts, and env. It silently dropped `--device` (sound-card capture, `/dev/snd`), the network mode (`--network host`), the real restart policy, mount propagation, and more. For audio-capture and host-network installs a port change or an upgrade would quietly strip the sound card or host networking. A dropped `--device /dev/snd` does not fail the health probe (the web UI still answers; only audio capture dies), so the existing apply-verify-rollback safety net cannot catch it.

This PR makes recreate faithful, with a hybrid approach: reproduce the flags real installs use, and hard-stop to a guided-manual path for anything that cannot be faithfully reproduced (never destroying the container in that case).

- **Reproduce a documented whitelist** in `buildRunArgs`: `--device` (simple and explicit-perms forms), non-default `--network` (host/none/named, and `-p` is omitted under host networking where it is meaningless), the real `--restart` policy (defaulting to `unless-stopped` only when inspect carries none), and `:ro` / propagation suffixes (for example `rshared`) on bind mounts.
- **Residual guard** `findUnreproducible`: a pure function returning the reasons a container cannot be reproduced (non-bind mounts, privileged, cap-add/drop, tmpfs, sysctls, ulimits, group-add, extra-hosts, dns/dns-search/dns-option, security-opt, device-cgroup-rules, GPU device-requests, custom runtime, custom user, compose-managed labels, a custom network carrying a static IP or aliases, multiple networks, and a port change requested on a host-network container).
- **`recreateContainer` returns a discriminated result** (`recreated` | `unsupported`) and runs the guard before `docker stop`/`rm`, so a non-reproducible container is left running and untouched while the caller surfaces manual steps.
- **Wiring:** `DockerDriver.setHostPort` maps `unsupported` to a `guided-manual` result; `safeApply.safeSetPort`'s auto path short-circuits to guided-manual (skipping the health poll) instead of misreporting a rollback; the PortCard UI already renders a guided-manual result.
- **Unify the upgrade path:** `app.tsx`'s `upgradeBirdNetGo` is routed through the shared `recreateContainer`, removing a second inline copy of the lossy recreate logic and the dead `DockerInspectResult` interface, so the upgrade path gets the same fidelity and the same guard.

Labels (beyond the compose guard) and the healthcheck are intentionally not reproduced: the image re-bakes its own `LABEL` and `HEALTHCHECK` when the same image is re-run, and a run-time override cannot be distinguished from an image-baked value via `docker inspect`.

## Test Plan

- [x] `npm run format:check && npm run eslint && npm run typecheck && npx vitest run && npm run build` all clean (228 tests).
- [x] Unit tests for every reproduced flag and every guard reason (table-driven), the no-destroy property of the guard, the setHostPort result mapping, and the safeApply guided-manual short-circuit. All `exec` mocked; no live docker.

## Follow-ups (not in this PR)

The podman migration (a later backlog item) should revisit two podman-specific notes left as comments here: podman's default runtime is `crun`/`oci` (not `runc`), so the custom-runtime guard will need a runtime allowlist; and the `Config.User` guard assumes the image runs as root, which holds today but would over-trigger guided-manual if a future image baked a `USER` directive (a safe degradation, not a silent drop).