### PR TITLE
Podman hardening: drive lifecycle actions by the detected runtime, prefer the running one

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -628,7 +628,7 @@ export const Application = () => {
         setUpgrading(true);
 
         try {
-            // Check if Docker is available first
+            // Check that a container runtime is available first
             if (!dockerStatus.available) {
                 alert('No container runtime is available. Please install Docker or Podman to upgrade BirdNET-Go.');
                 return;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -51,6 +51,7 @@ import type { ContainerStatus, DockerStatus, HealthStatus, LogEntry, SystemdStat
 import { detectDeployment } from './deployment/detect';
 import { getDriver } from './deployment/driver';
 import { recreateContainer } from './deployment/recreate';
+import { runtimeBin } from './deployment/runtime';
 import type { Deployment } from './deployment/types';
 import { PortCard } from './components/PortCard';
 import {
@@ -140,13 +141,19 @@ export const Application = () => {
         }
 
         try {
-            const logs = await cockpit.spawn(['docker', 'logs', '--tail', '200', containerStatus.containerId]);
+            const logs = await cockpit.spawn([
+                runtimeBin(deployment.runtime),
+                'logs',
+                '--tail',
+                '200',
+                containerStatus.containerId,
+            ]);
             setContainerLogs(logs);
         } catch (error) {
             console.error('Error fetching logs:', error);
             setContainerLogs('Error fetching logs');
         }
-    }, [containerStatus.exists, containerStatus.containerId]);
+    }, [containerStatus.exists, containerStatus.containerId, deployment.runtime]);
 
     const fetchLogFiles = useCallback(async () => {
         try {
@@ -578,7 +585,7 @@ export const Application = () => {
     const createContainer = async () => {
         try {
             await cockpit.spawn([
-                'docker',
+                runtimeBin(deployment.runtime),
                 'run',
                 '-d',
                 '--name',
@@ -601,7 +608,7 @@ export const Application = () => {
 
     const pullImage = async () => {
         try {
-            await cockpit.spawn(['docker', 'pull', getImageRef()]);
+            await cockpit.spawn([runtimeBin(deployment.runtime), 'pull', getImageRef()]);
             await refreshStatus();
         } catch (error) {
             console.error('Error pulling image:', error);
@@ -623,12 +630,12 @@ export const Application = () => {
         try {
             // Check if Docker is available first
             if (!dockerStatus.available) {
-                alert('Docker is not available. Please install Docker to upgrade BirdNET-Go.');
+                alert('No container runtime is available. Please install Docker or Podman to upgrade BirdNET-Go.');
                 return;
             }
 
             if (!dockerStatus.running) {
-                alert('Docker service is not running. Please start Docker service first.');
+                alert('The container runtime is not running. Please start Docker or Podman first.');
                 return;
             }
 
@@ -646,7 +653,8 @@ export const Application = () => {
             const imageName = getImageRef(imageTag);
 
             // Pull the new image
-            await cockpit.spawn(['docker', 'pull', imageName]);
+            const bin = runtimeBin(deployment.runtime);
+            await cockpit.spawn([bin, 'pull', imageName]);
 
             if (systemdStatus.exists) {
                 // For systemd service that runs Docker, just restart the service
@@ -656,7 +664,7 @@ export const Application = () => {
                 // Recreate the standalone container on the new image, reproducing its
                 // device/network/restart/mount flags. If the container carries settings
                 // that cannot be safely reproduced, leave it running and guide the user.
-                const result = await recreateContainer('docker', containerStatus.containerId, {
+                const result = await recreateContainer(bin, containerStatus.containerId, {
                     image: imageName,
                     internalPort: 8080,
                 });

--- a/src/deployment/detect.test.ts
+++ b/src/deployment/detect.test.ts
@@ -97,4 +97,72 @@ describe('detectDeployment', () => {
         expect(d.kind).toBe('native-systemd');
         expect(d.systemdStatusText).toBe('active');
     });
+
+    it('detects a running docker daemon as docker', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: true, out: 'Docker version 27' };
+            if (cmd.includes('is-active docker')) return { ok: true, out: 'active' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.runtime).toBe('docker');
+        expect(d.dockerRunning).toBe(true);
+    });
+
+    it('prefers a running podman when the docker CLI exists but its daemon is down', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: true, out: 'Docker version 27' };
+            if (cmd.includes('is-active docker')) return { ok: true, out: 'inactive' };
+            if (cmd.includes('podman --version')) return { ok: true, out: 'podman version 5' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.runtime).toBe('podman');
+        expect(d.dockerRunning).toBe(true);
+    });
+
+    it('reports docker present-but-stopped when its daemon is down and there is no podman', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: true, out: 'Docker version 27' };
+            if (cmd.includes('is-active docker')) return { ok: true, out: 'inactive' };
+            if (cmd.includes('podman --version')) return { ok: false, out: '' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.runtime).toBe('docker');
+        expect(d.dockerAvailable).toBe(true);
+        expect(d.dockerRunning).toBe(false);
+    });
+
+    it('detects podman when the docker CLI is absent', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: false, out: '' };
+            if (cmd.includes('podman --version')) return { ok: true, out: 'podman version 5' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.runtime).toBe('podman');
+        expect(d.dockerRunning).toBe(true);
+    });
+
+    it('reports no runtime when neither docker nor podman is present', async () => {
+        const { detectDeployment } = await import('./detect');
+        probeMock.mockImplementation((argv: string[]) => {
+            const cmd = argv.join(' ');
+            if (cmd.includes('docker --version')) return { ok: false, out: '' };
+            if (cmd.includes('podman --version')) return { ok: false, out: '' };
+            return { ok: false, out: '' };
+        });
+        const d = await detectDeployment('localhost');
+        expect(d.runtime).toBe(null);
+        expect(d.dockerAvailable).toBe(false);
+    });
 });

--- a/src/deployment/detect.ts
+++ b/src/deployment/detect.ts
@@ -20,6 +20,7 @@
 import { CONTAINER_NAME, DOCKER_IMAGE, SERVICE_NAME, getHealthUrl } from '../config';
 import { classifyDeployment } from './classify';
 import { probe } from './exec';
+import { runtimeBin } from './runtime';
 import type { ContainerRuntime, DetectionSignals, Deployment } from './types';
 
 export const parseContainerLine = (line: string): DetectionSignals['container'] | null => {
@@ -64,18 +65,21 @@ export const parseHostPort = (inspectJson: string, internalPort: number): number
 
 const detectDocker = async (): Promise<{ runtime: ContainerRuntime; docker: DetectionSignals['docker'] }> => {
     const dv = await probe(['docker', '--version']);
-    if (dv.ok) {
-        const active = await probe(['systemctl', 'is-active', 'docker']);
-        return { runtime: 'docker', docker: { available: true, running: active.out === 'active', version: dv.out } };
+    const dockerActive = dv.ok ? (await probe(['systemctl', 'is-active', 'docker'])).out === 'active' : false;
+    if (dv.ok && dockerActive) {
+        return { runtime: 'docker', docker: { available: true, running: true, version: dv.out } };
     }
+    // Docker CLI is missing or its daemon is down: prefer a runtime that is actually running.
     const pv = await probe(['podman', '--version']);
     if (pv.ok) return { runtime: 'podman', docker: { available: true, running: true, version: pv.out } };
+    // No podman; report docker present-but-stopped if its CLI exists, otherwise nothing.
+    if (dv.ok) return { runtime: 'docker', docker: { available: true, running: false, version: dv.out } };
     return { runtime: null, docker: { available: false, running: false } };
 };
 
 export const detectDeployment = async (hostname: string): Promise<Deployment> => {
     const { runtime, docker } = await detectDocker();
-    const bin = runtime ?? 'docker';
+    const bin = runtimeBin(runtime);
 
     // image present?
     const images = runtime ? (await probe([bin, 'images', '--format', '{{.Repository}}:{{.Tag}}'])).out : '';

--- a/src/deployment/dockerDriver.ts
+++ b/src/deployment/dockerDriver.ts
@@ -21,13 +21,14 @@ import { deriveCapabilities } from './capabilities';
 import type { DeploymentDriver, PortChangeResult } from './driver';
 import { exec } from './exec';
 import { recreateContainer } from './recreate';
+import { runtimeBin } from './runtime';
 import type { Deployment, DeploymentCapabilities } from './types';
 
 export class DockerDriver implements DeploymentDriver {
     constructor(private readonly d: Deployment) {}
 
-    private bin(): string {
-        return this.d.runtime === 'podman' ? 'podman' : 'docker';
+    private bin(): 'docker' | 'podman' {
+        return runtimeBin(this.d.runtime);
     }
 
     async start(): Promise<void> {

--- a/src/deployment/runtime.test.ts
+++ b/src/deployment/runtime.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { runtimeBin } from './runtime';
+
+describe('runtimeBin', () => {
+    it('maps docker to the docker binary', () => {
+        expect(runtimeBin('docker')).toBe('docker');
+    });
+    it('maps podman to the podman binary', () => {
+        expect(runtimeBin('podman')).toBe('podman');
+    });
+    it('falls back to docker when no runtime was detected (null)', () => {
+        expect(runtimeBin(null)).toBe('docker');
+    });
+});

--- a/src/deployment/runtime.ts
+++ b/src/deployment/runtime.ts
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { ContainerRuntime } from './types';
+
+/**
+ * Map a detected container runtime to the CLI binary used to drive it.
+ * A null runtime (none detected) falls back to 'docker' to preserve prior behavior.
+ */
+export const runtimeBin = (runtime: ContainerRuntime): 'docker' | 'podman' =>
+    runtime === 'podman' ? 'podman' : 'docker';


### PR DESCRIPTION
## Summary

M0 added podman detection, but the container-lifecycle UI actions still spawned `docker` literally, and detection preferred a stopped docker over a running podman. On a podman-only host, create/pull/upgrade/logs would fail, and a host with the docker CLI installed but its daemon down (plus podman running) was misdetected as docker. This closes both gaps.

- **`runtimeBin(runtime)` helper** (new `src/deployment/runtime.ts`): a pure mapping from the detected runtime to its CLI binary (`'podman'` -> `'podman'`, everything else including `null` -> `'docker'`). It unifies three call sites: `DockerDriver.bin()`, `detect.ts`'s binary derivation (previously `runtime ?? 'docker'`), and the new app.tsx uses.
- **`detectDocker` prefers the running runtime**: docker active -> docker; docker present but its daemon inactive AND podman present -> podman; docker present-but-stopped with no podman -> docker (reported stopped); no docker + podman -> podman; neither -> none. The is-active probe is gated so it only fires when the docker CLI exists.
- **app.tsx lifecycle actions** (`fetchLogs`, `createContainer`, `pullImage`, `upgradeBirdNetGo`'s image pull and recreate) now use `runtimeBin(deployment.runtime)` instead of a hardcoded `docker`. The two Docker-specific upgrade alerts are reworded to reference the container runtime generically so podman users do not see a Docker message.

This is the small follow-up to the container-recreate fidelity work (PR #120): with `recreateContainer` already taking a `bin` parameter, the upgrade path now passes the detected runtime instead of `'docker'`.

## Test Plan

- [x] `npm run format:check && npm run eslint && npm run typecheck && npx vitest run && npm run build` all clean (236 tests).
- [x] `runtime.test.ts` covers all three `runtimeBin` inputs; `detect.test.ts` adds five cases covering every detection outcome (including the new docker-down-plus-podman-running preference). All `probe`/`exec` mocked; no live docker/podman.
- [x] Verified no residual hardcoded `docker` command path remains: the only `docker` literals left are the helper fallback, detection probes (correctly docker-specific), type annotations, and `kind.startsWith('docker')` container-vs-native discriminators (podman containers keep a `docker-*` kind and route through `DockerDriver`, whose `bin()` returns the right binary).

## Out of scope

- Full UI-to-driver migration of pull/create/logs (later UI-cleanup milestone).
- Remaining "Docker"-worded status strings in the existing status UI (separate i18n/UI pass).
- podman rootless privileged-port handling beyond the existing advisory.