### PR TITLE
Bump prettier, stylelint, typescript-eslint to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,9 +7117,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/src/deployment/types.ts
+++ b/src/deployment/types.ts
@@ -18,12 +18,7 @@
  */
 
 export type DeploymentKind =
-    | 'docker-standalone'
-    | 'docker-compose'
-    | 'docker-systemd'
-    | 'native-systemd'
-    | 'native'
-    | 'none';
+    'docker-standalone' | 'docker-compose' | 'docker-systemd' | 'native-systemd' | 'native' | 'none';
 
 export type ContainerRuntime = 'docker' | 'podman' | null;
 


### PR DESCRIPTION
## Summary
- Updates prettier (3.8.4 -> 3.9.4), stylelint (17.13.0 -> 17.14.0), and typescript-eslint (8.62.0 -> 8.62.1) to their latest versions within the existing package.json semver ranges
- Reformats `src/deployment/types.ts` to match prettier 3.9's updated union type wrapping rule
- eslint stays at 9.39.4; 10.x is a major version bump outside the current range and needs separate review for breaking changes

## Test plan
- [x] `npm run eslint` passes
- [x] `npm run stylelint` passes
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (236 tests)
- [x] `npm audit` reports 0 vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted a deployment type declaration for consistency. No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->